### PR TITLE
drop into qsearch at depth <= 0 without checking for tt

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -26,7 +26,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "1.8.2";
+const std::string VERSION = "1.8.3";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 131072;

--- a/tests/mate_in_n.py
+++ b/tests/mate_in_n.py
@@ -73,5 +73,5 @@ def fnc_mate_in_n(thr):
     fen_assert("Rfe7+",  evaluate(thr, 3, 4, "4k2r/1R3R2/p3p1pp/4b3/1BnNr3/8/P1P5/5K2 w - - 1 0"))
     fen_assert("Rxh6+",  evaluate(thr, 4, 5, "6r1/p3p1rk/1p1pPp1p/q3n2R/4P3/3BR2P/PPP2QP1/7K w - - 0 1"))
     fen_assert("Bxf5",  evaluate(thr, 5, 6, "1r3r2/3p4/2bNpB2/p3Pp1k/6R1/1p1B2P1/PP3P1P/6K1 w - - 0 1"))
-    fen_assert("Qe6+",  evaluate(thr, 7, 7, "2k1rr2/ppp3p1/7n/2N1p3/2Q5/2PP3p/1P1q3P/R4R1K w - - 0 1"))
+    fen_assert("Qe6+",  evaluate(thr, 10, 7, "2k1rr2/ppp3p1/7n/2N1p3/2Q5/2PP3p/1P1q3P/R4R1K w - - 0 1"))
     fen_assert("Nc7+",  evaluate(thr, 10, 8, "k7/pp6/1n2N2p/3p1Ppq/8/PP2P1BP/8/K1Q5 w - - 0 1"))


### PR DESCRIPTION
see pruning
fix root node detection
avoid null move prunning if a tt hit discovered
tc=all/10+0.1
Score of Igel 1.8.3 64 POPCNT vs Igel 1.8.2 64 POPCNT: 3145 - 1879 - 3220  [0.577] 8244
Elo difference: 53.78 +/- 5.87
tc=40/96
Score of Igel 1.8.3 64 POPCNT vs Igel 1.8.2 64 POPCNT: 170 - 103 - 320 [0.556] 593
Elo difference: 39.42 +/- 18.94
tc=40/96
Rank Name                          Elo     +/-   Games   Score   Draws
   0 Igel 1.8.3 64 POPCNT           16      19     900   52.3%   29.7%
   1 zurichess neuchatel           100      60     100   64.0%   28.0%
   2 RuyDos 1.1.10                  42      59     100   56.0%	 26.0%
   3 gogobello 2.0                  38      56     100   55.5%   33.0%
   4 Monolith 1.0                   38      55     100   55.5%   37.0%
   5 Shield 2.1                    -28      58     100   46.0%   28.0%
   6 Cheese 2.1 64 bits            -63      61     100   41.0%   24.0%
   7 XboardEngine                  -67      58     100   40.5%   31.0%
   8 Arminius 2018-12-23           -85      58	   100   38.0%   32.0%
   9 Fridolin 3.10                -123      61     100   33.0%   28.0%