### PR TITLE
TCEC SMP improvements (Igel 2.1.2 TCEC#3)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1206,7 +1206,7 @@ void Search::startSearch(Time time, int depth, EVAL alpha, EVAL beta, bool ponde
         //  Start worker threads if Threads option is configured
         //
 
-        lazySmpWork = (m_thc) && (!smpStarted) && (m_depth > 1);
+        lazySmpWork = (m_thc) && (!smpStarted);
 
         if (lazySmpWork) {
             smpStarted = true;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -163,6 +163,13 @@ EVAL Search::searchRoot(EVAL alpha, EVAL beta, int depth)
     //  Different move ordering for lazy smp threads
     //
 
+    if (!m_principalSearcher && depth == 1 && mvSize >= 2) {
+        int j = 0;
+        for (size_t i = mvSize - 1; i > 0; --i) {
+            mvlist.Swap(i, j++);
+        }
+    }
+
     std::vector<Move> quietMoves;
 
     for (size_t i = 0; i < mvSize; ++i) {
@@ -1355,30 +1362,8 @@ void Search::startSearch(Time time, int depth, EVAL alpha, EVAL beta, bool ponde
 
     waitUntilCompletion();
 
-    if (m_principalSearcher) {
-
-        /*std::map<Move, int64_t> votes;
-        auto minScore = m_score;
-
-        for (unsigned int i = 0; i < m_thc; ++i)
-            minScore = std::min(minScore, m_threadParams[i].m_score);
-
-        int64_t bestScore = (m_score - minScore + 14) * m_completedDepth;
-        votes[m_best] = bestScore;
-
-        for (unsigned int i = 0; i < m_thc; ++i)
-            votes[m_threadParams[i].m_best] += (m_threadParams[i].m_score - minScore + 14) * m_threadParams[i].m_completedDepth;
-
-        for (const auto & v : votes) {
-            if (v.second > bestScore) {
-                bestScore = v.second;
-                m_best = v.first;
-            }
-        }
-        */
-
+    if (m_principalSearcher)
         printBestMove(this, m_position, m_best, ponder);
-    }
 }
 
 void Search::setPonderHit()

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1060,9 +1060,8 @@ void Search::stopWorkerThreads()
     indicateWorkersStop();
 
     for (unsigned int i = 0; i < m_thc; ++i) {
-        while (m_threadParams[i].m_lazyDepth) {
-            std::this_thread::sleep_for(chrono::duration<double, milli>(1));
-        }
+        while (m_threadParams[i].m_lazyDepth)
+            ;
     }
 }
 
@@ -1072,7 +1071,7 @@ void Search::waitUntilCompletion()
 
     if (m_principalSearcher && (m_flags & MODE_ANALYZE)) {
         while ((m_flags & SEARCH_TERMINATED) == 0)
-            std::this_thread::sleep_for(chrono::duration<double, milli>(1)); // we must wait explicitely for stop command
+            ; // we must wait explicitely for stop command
     }
 
     m_waitStarted = false;
@@ -1235,8 +1234,8 @@ void Search::startSearch(Time time, int depth, EVAL alpha, EVAL beta, bool ponde
             for (unsigned int i = 0; i < m_thc; ++i) {
                 m_nodes += m_threadParams[i].m_nodes;
                 m_tbHits += m_threadParams[i].m_tbHits;
-                m_threadParams[i].m_nodes = 0;
-                m_threadParams[i].m_tbHits = 0;
+                /*m_threadParams[i].m_nodes = 0;
+                m_threadParams[i].m_tbHits = 0;*/
             }
         }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1364,7 +1364,7 @@ void Search::startSearch(Time time, int depth, EVAL alpha, EVAL beta, bool ponde
 
     if (m_principalSearcher) {
 
-        std::map<Move, int64_t> votes;
+        /*std::map<Move, int64_t> votes;
         auto minScore = m_score;
 
         for (unsigned int i = 0; i < m_thc; ++i)
@@ -1382,6 +1382,7 @@ void Search::startSearch(Time time, int depth, EVAL alpha, EVAL beta, bool ponde
                 m_best = v.first;
             }
         }
+        */
 
         printBestMove(this, m_position, m_best, ponder);
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1206,7 +1206,7 @@ void Search::startSearch(Time time, int depth, EVAL alpha, EVAL beta, bool ponde
         //  Start worker threads if Threads option is configured
         //
 
-        lazySmpWork = (m_thc) && (!smpStarted);
+        lazySmpWork = (m_thc) && (!smpStarted) && (m_depth > 13);
 
         if (lazySmpWork) {
             smpStarted = true;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -163,13 +163,6 @@ EVAL Search::searchRoot(EVAL alpha, EVAL beta, int depth)
     //  Different move ordering for lazy smp threads
     //
 
-    if (!m_principalSearcher && depth == 1 && mvSize >= 2) {
-        int j = 0;
-        for (size_t i = mvSize - 1; i > 0; --i) {
-            mvlist.Swap(i, j++);
-        }
-    }
-
     std::vector<Move> quietMoves;
 
     for (size_t i = 0; i < mvSize; ++i) {
@@ -1206,7 +1199,7 @@ void Search::startSearch(Time time, int depth, EVAL alpha, EVAL beta, bool ponde
         //  Start worker threads if Threads option is configured
         //
 
-        lazySmpWork = (m_thc) && (!smpStarted) && (m_depth > 13);
+        lazySmpWork = (m_thc) && (!smpStarted) && (m_depth > 1);
 
         if (lazySmpWork) {
             smpStarted = true;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1031,7 +1031,7 @@ void Search::startWorkerThreads(Time time)
         m_threadParams[i].m_nodes = 0;
         m_threadParams[i].m_selDepth = 0;
         m_threadParams[i].m_tbHits = 0;
-        m_threadParams[i].setPosition(m_position);
+        m_threadParams[i].m_position.SetFEN(m_position.FEN());
         m_threadParams[i].setTime(time);
         m_threadParams[i].setLevel(m_level);
         m_threadParams[i].m_t0 = m_t0;

--- a/src/search.h
+++ b/src/search.h
@@ -89,7 +89,7 @@ private:
     bool ProbeHash(TEntry & hentry);
     bool isGameOver(Position & pos, string & result, string & comment, Move & bestMove, int & legalMoves);
     Move forceFetchPonder(Position & pos, const Move & bestMove);
-    void printPV(const Position& pos, int iter, int selDepth, EVAL score, const Move* pv, int pvSize, Move mv);
+    void printPV(const Position& pos, int iter, int selDepth, EVAL score, const Move* pv, int pvSize, Move mv, uint64_t sumNodes, uint64_t sumHits);
 
     bool checkLimits();
     void releaseHelperThreads();

--- a/src/search.h
+++ b/src/search.h
@@ -102,6 +102,7 @@ private:
     U32 m_t0;
     volatile U8 m_flags;
     int m_depth;
+    int m_completedDepth;
     int m_syzygyDepth;
     int m_selDepth;
     int m_iterPVSize;
@@ -137,7 +138,7 @@ private:
     volatile int m_lazyDepth;
     int m_lazyAlpha;
     int m_lazyBeta;
-    EVAL m_bestSmpEval;
+    EVAL m_score;
     Move m_best;
     volatile bool m_smpThreadExit;
     bool m_lazyPonder;

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -92,6 +92,7 @@ bool TTable::setHashSize(double mb)
     m_hashSize = int(1024 * 1024 * mb / sizeof(TEntry));
     m_hash = reinterpret_cast<TEntry*>(malloc(sizeof(TEntry) * m_hashSize));
 
+    clearHash();
     assert(m_hash);
     return m_hash != nullptr;
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.1.2 TCEC#2";
+const std::string VERSION = "2.1.2 TCEC#3";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 131072;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.1.2 TCEC#3";
+const std::string VERSION = "2.1.2 #3";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 131072;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.1.2 TCEC#3";
+const std::string VERSION = "2.1.2 TCEC#5";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 131072;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.1.0 v7";
+const std::string VERSION = "2.1.0 v9";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 131072;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.1.0 v9";
+const std::string VERSION = "2.1.2 TCEC#2";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 131072;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.1.2 TCEC#5";
+const std::string VERSION = "2.1.2 TCEC#3";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 131072;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.1.2 #3";
+const std::string VERSION = "2.1.2 TCEC#3";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 131072;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.1.0";
+const std::string VERSION = "2.1.0 v7";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 131072;


### PR DESCRIPTION
- remove sleeps when waiting for child smp threads to stop and when waiting for ponder command
- clear tt on resize
- avoid copying the m_position object when starting smp threads and instead set fen
- prevent cache coherency issues when calculating tbhits and nodes count