### PR TITLE
start smp threads before the main search and randomly skip depths

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -106,6 +106,7 @@ private:
     int m_syzygyDepth;
     int m_selDepth;
     int m_iterPVSize;
+    int m_index;
     MoveList m_lists[MAX_PLY];
     Move m_pv[MAX_PLY][MAX_PLY];
     int m_pvSize[MAX_PLY];
@@ -152,6 +153,9 @@ private:
     static constexpr int m_fmpDepth[]        = { 3, 2           };
     static constexpr int m_fmpHistoryLimit[] = { -2000, -4000   };
     static constexpr int m_fpHistoryLimit[]  = { 12000, 6000    };
+    static constexpr int m_skipSize[]        = { 1, 1, 1, 2, 2, 2, 1, 3, 2, 2, 1, 3, 3, 2, 2, 1 };
+    static constexpr int m_skipDepths[]      = { 1, 2, 2, 4, 4, 3, 2, 5, 4, 3, 2, 6, 5, 4, 3, 2 };
+    static constexpr int m_SMPCycles         = 16;
     bool m_terminateSmp;
     bool m_waitStarted;
     int m_level;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.1.2 next4";
+const std::string VERSION = "2.1.2 next5";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 131072;


### PR DESCRIPTION
Score of Igel 2.1.2 next5.1 64 POPCNT vs Igel 2.1.2 next4.1 64 POPCNT: 78 - 68 - 173  [0.516] 319
Elo difference: 10.89 +/- 25.80