### PR TITLE
make pruning only after playing at least a single move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -512,7 +512,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         History::HistoryHeuristics history{};
         History::fetchHistory(this, mv, ply, history);
 
-        if (quietMove && bestMove) {
+        if (quietMove && legalMoves >= 1) {
 
             if (futilityMargin <= alpha
                 && depth <= 8
@@ -529,7 +529,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
                 continue;
         }
 
-        if (depth <= 8) {
+        if (depth <= 8 && legalMoves >= 1) {
             if (MoveEval::SEE(this, mv) < seeMargin[quietMove])
                 continue;
         }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.1.2 next7";
+const std::string VERSION = "2.1.2 next8";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;


### PR DESCRIPTION
tc=all/10+0.1
hash=256
Score of Igel 2.1.2 next8 64 POPCNT vs Igel 2.1.2 next7 64 POPCNT: 350 - 230 - 428  [0.560] 1008
Elo difference: 41.56 +/- 16.29