### PR TITLE
more aggressive lmr

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -568,7 +568,6 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             //
 
             newDepth += extensionRequired(mv, lastMove, inCheck, ply, onPV, quietMoves.size(), history.cmhistory, history.fmhistory);
-            auto extended = newDepth != (depth - 1);
 
             EVAL e;
             if (legalMoves == 1)
@@ -581,7 +580,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
                 int reduction = 0;
 
-                if (quietMove && !extended && !inCheck && !m_position.InCheck() && !MoveEval::isSpecialMove(mv, this)) {
+                if (depth >= 3 && quietMove) {
                     reduction = m_logLMRTable[std::min(depth, 63)][std::min(legalMoves, 63)];
 
                     reduction -= mv == m_killerMoves[ply][0]

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.2.1 +0";
+const std::string VERSION = "2.2.1 +1";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;


### PR DESCRIPTION
os=linux
tc=all/10+0.1
hash=16
threads=1
Score of Igel 2.2.1 +1 64 POPCNT vs Igel 2.2.1 +0 64 POPCNT: 828 - 677 - 1304  [0.527] 2809
Elo difference: 18.69 +/- 9.40

os=windows
tc=all/10+0.1
hash=256
threads=1
Score of Igel 2.2.1 +1 64 POPCNT vs Cheng 4.39: 864 - 949 - 911  [0.484] 2724
Elo difference: -10.84 +/- 10.63