### PR TITLE
Release Igel 2.3.0

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -3,6 +3,18 @@ Igel chess engine
 (c) 2002-2018 Vladimir Medvedev <vrm@bk.ru>
 (c) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 
+Igel 2.3.0
+-------------
+27-Dec-2019
+
+- Rename uci option 'Level' into 'Skill Level'
+- Do not apply razoring when in check
+- Do not apply 'improving' factor when in check
+- Do not prune quiets at root
+- Fetch history only when a quiet move is detected
+- Improve branching factor and apply LMR more aggressively
+- Fix compilaton issue with clang compiler
+
 Igel 2.2.0
 -------------
 23-Dec-2019

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -262,7 +262,6 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 {
     m_pvSize[ply] = 0;
     m_selDepth = std::max(ply, m_selDepth);
-    ++m_nodes;
 
     auto inCheck = m_position.InCheck();
 
@@ -272,6 +271,8 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
     if (!inCheck && depth <= 0 && m_level > MEDIUM_LEVEL)
         return qSearch(alpha, beta, ply);
+
+    ++m_nodes;
 
     if (!rootNode && checkLimits())
         return -INFINITY_SCORE;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.2.1 +1";
+const std::string VERSION = "2.3.0";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;
@@ -130,7 +130,7 @@ void Uci::onUci()
     cout << "option name Ponder type check" <<
         " default false" << endl;
 
-    std::cout << "option name Level type spin" <<
+    std::cout << "option name Skill Level type spin" <<
         " default " << DEFAULT_LEVEL <<
         " min "		<< MIN_LEVEL	<<
         " max "		<< MAX_LEVEL << std::endl;


### PR DESCRIPTION
Igel 2.3.0
-------------
27-Dec-2019

- Rename uci option 'Level' into 'Skill Level'
- Do not apply razoring when in check
- Do not apply 'improving' factor when in check
- Do not prune quiets at root
- Fetch history only when a quiet move is detected
- Improve branching factor and apply LMR more aggressively
- Fix compilaton issue with clang compiler