### PR TITLE
Release Igel 2.3.0 (TCEC S17 QL version)

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.2.2 +1";
+const std::string VERSION = "2.3.0";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;


### PR DESCRIPTION
os=linux
hash=256
tc=40/102 (CCRL 40/4)
Score of Igel 2.3.0 64 POPCNT vs Igel 2.2.2 64 POPCNT: 331 - 195 - 805  [0.551] 1331
Elo difference: 35.62 +/- 11.69