### PR TITLE
Release Igel 2.3.0 (TCEC S17 QL version)

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -26,7 +26,7 @@
 /*static */constexpr int History::s_historyMultiplier;
 /*static */constexpr int History::s_historyDivisor;
 
-/*static */void History::updateHistory(Search * pSearch, std::vector<Move> quetMoves, int ply, int bonus)
+/*static */void History::updateHistory(Search * pSearch, const std::vector<Move>& quetMoves, int ply, int bonus)
 {
     assert(ply < MAX_PLY);
 

--- a/src/history.h
+++ b/src/history.h
@@ -42,7 +42,7 @@ public:
     };
 
 public:
-    static void updateHistory(Search * pSearch, std::vector<Move> quetMoves, int ply, int bonus);
+    static void updateHistory(Search * pSearch, const std::vector<Move> & quetMoves, int ply, int bonus);
     static void setKillerMove(Search * pSearch, Move mv, int ply);
     static void fetchHistory(Search * pSearch, Move mv, int ply, HistoryHeuristics & hh);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -589,7 +589,9 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
                     reduction -= std::max(-2, std::min(2, (history.history + history.cmhistory + history.fmhistory) / 5000));
 
-                    if (reduction < 0)
+                    if (reduction >= newDepth)
+                        reduction = newDepth - 1;
+                    else if (reduction < 0)
                         reduction = 0;
                 }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.2.2 +1";
+const std::string VERSION = "2.3.0";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.2.1";
+const std::string VERSION = "2.2.2 +1";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;


### PR DESCRIPTION
os=linux
hash=256
tc=40/102 (CCRL 40/4)
Score of Igel 2.3.0 64 POPCNT vs Igel 2.2.2 64 POPCNT: 331 - 195 - 805  [0.551] 1331
Elo difference: 35.62 +/- 11.69