### PR TITLE
unified killers based on non tactical moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -240,7 +240,7 @@ EVAL Search::searchRoot(EVAL alpha, EVAL beta, int depth)
 
             if (alpha >= beta) {
                 type = HASH_BETA;
-                if (!mv.Captured() && !mv.Promotion())
+                if (!MoveEval::isTacticalMove(mv))
                     History::setKillerMove(this, mv, ply);
                 break;
             }
@@ -622,7 +622,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             if (alpha >= beta)
             {
                 type = HASH_BETA;
-                if (!mv.Captured())
+                if (!MoveEval::isTacticalMove(mv))
                     History::setKillerMove(this, mv, ply);
                 break;
             }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.3.0";
+const std::string VERSION = "2.3.1-a1";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;


### PR DESCRIPTION
tc=all/10+0.1
hash=256
os=linux
Score of Igel 2.3.1-a1 64 POPCNT vs Igel 2.3.0 64 POPCNT: 658 - 643 - 952  [0.503] 2253
Elo difference: 2.31 +/- 10.89