### PR TITLE
do not tt cutoff on pv in qsearch

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.3.1-a1";
+const std::string VERSION = "2.3.1-a2";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;


### PR DESCRIPTION
tc=40/102
hash=256
os=linux
Score of Igel 2.3.1-a2 64 POPCNT vs Igel 2.3.1-a1 64 POPCNT: 63 - 47 - 163  [0.529] 273
Elo difference: 20.39 +/- 26.15