### PR TITLE
always use hash moves in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -656,12 +656,12 @@ EVAL Search::qSearch(EVAL alpha, EVAL beta, int ply)
 
     Move hashMove{};
     TEntry hEntry;
+    EVAL ttScore = -CHECKMATE_SCORE + ply;
     auto ttHit = false;
-    EVAL ttScore;
 
     if (ProbeHash(hEntry)) {
         ttScore = hEntry.score();
-        ttHit = hEntry.type() == HASH_EXACT;
+        ttHit = true;
         if (ttScore > CHECKMATE_SCORE - 50 && ttScore <= CHECKMATE_SCORE)
             ttScore -= ply;
         if (ttScore < -CHECKMATE_SCORE + 50 && ttScore >= -CHECKMATE_SCORE)
@@ -688,8 +688,7 @@ EVAL Search::qSearch(EVAL alpha, EVAL beta, int ply)
     {
         bestScore = m_evaluator->evaluate(m_position);
 
-        if (ttHit)
-        {
+        if (ttHit) {
             if ((hEntry.type() == HASH_BETA && ttScore > bestScore) ||
                 (hEntry.type() == HASH_ALPHA && ttScore < bestScore) ||
                 (hEntry.type() == HASH_EXACT))
@@ -713,7 +712,7 @@ EVAL Search::qSearch(EVAL alpha, EVAL beta, int ply)
 
     int legalMoves = 0;
     auto mvSize = mvlist.Size();
-    Move bestMove = ttHit ? hEntry.move() : Move{};
+    Move bestMove = hashMove;
 
     for (size_t i = 0; i < mvSize; ++i) {
         Move mv = MoveEval::getNextBest(mvlist, i);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.3.1-a2";
+const std::string VERSION = "2.3.1-a3";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;


### PR DESCRIPTION
tc=all/10+0.1
hash=16
os=linux
Score of Igel 2.3.1-a3 64 POPCNT vs Igel 2.3.1-a2 64 POPCNT: 764 - 684 - 988  [0.516] 2436
Elo difference: 11.41 +/- 10.63