### PR TITLE
more strict conditions when pruning

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -50,6 +50,8 @@ const U8 MODE_SILENT  = 0x10;
 #define isCheckMateScore(score)        ((score) <= -CHECKMATE_SCORE + 50|| \
                                         (score) >=  CHECKMATE_SCORE - 50)
 
+#define MATED_IN_MAX (MAX_PLY - CHECKMATE_SCORE)
+
 class Search
 {
     friend class History;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.3.1-b1";
+const std::string VERSION = "2.3.1-b2";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;


### PR DESCRIPTION
```
Finished game 1000 (Stockfish 10 64 POPCNT vs Igel 2.3.1-b2 64 POPCNT): 1-0 {White mates}
Rank Name                          Elo     +/-   Games   Score   Draws
   0 Igel 2.3.1-b2 64 POPCNT       -63      17    1000   41.0%   34.9%
   1 Stockfish 10 64 POPCNT        494     115     100   94.5%   11.0%
   2 Xiphos 0.6 BMI2               308      67     100   85.5%   27.0%
   3 Andscacs 0.95                 156      54     100   71.0%   40.0%
   4 RubiChess 1.6                 151      52     100   70.5%   43.0%
   5 Pedone 1.9                    119      51     100   66.5%   45.0%
   6 Strelka 5.5 x64                89      50     100   62.5%   47.0%
   7 Vajolet2 2.8.0                 70      51     100   60.0%   44.0%
   8 Winter 0.7 BMI2               -74      56     100   39.5%   35.0%
   9 zurichess neuchatel          -151      54     100   29.5%   41.0%
  10 GreKo 2018.08                -382      90     100   10.0%   16.0%
Finished match
```