### PR TITLE
re-write of aspiration windows search

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -107,7 +107,6 @@ private:
     U32 m_t0;
     volatile U8 m_flags;
     int m_depth;
-    int m_completedDepth;
     int m_syzygyDepth;
     int m_selDepth;
     int m_iterPVSize;
@@ -143,7 +142,6 @@ private:
     volatile int m_lazyDepth;
     int m_lazyAlpha;
     int m_lazyBeta;
-    EVAL m_score;
     Move m_best;
     volatile bool m_smpThreadExit;
     bool m_lazyPonder;

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -168,9 +168,6 @@ bool Time::evaluate()
 
 bool Time::adjust(bool onPv, int depth, EVAL score)
 {
-    if (abs(score) >= INFINITY_SCORE)
-        return false;
-
     //
     //  Do not bother with shallow depth
     //
@@ -223,7 +220,7 @@ bool Time::adjust(bool onPv, int depth, EVAL score)
 void Time::resetAdjustment()
 {
     m_onPv  = false;
-    m_prevScore = -INFINITY_SCORE;
+    m_prevScore = DRAW_SCORE;
 }
 
 U32 Time::getSoftLimit()

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -36,13 +36,8 @@ TTable & TTable::instance()
 
 bool TTable::record(Move mv, EVAL score, U8 depth, int ply, U8 type, U64 hash0)
 {
-    if (abs(score) >= INFINITY_SCORE)
-        return false;
-
     assert(m_hash);
     assert(m_hashSize);
-    assert(score <= INFINITY_SCORE);
-    assert(score >= -INFINITY_SCORE);
 
     size_t index = hash0 % m_hashSize;
     TEntry & entry = m_hash[index];

--- a/src/types.h
+++ b/src/types.h
@@ -129,10 +129,10 @@ enum
     DIR_DR = 7
 };
 
-const EVAL INFINITY_SCORE  = 50000;
-const EVAL CHECKMATE_SCORE = 32767;
-const EVAL TBBASE_SCORE    = 22767;
-const EVAL DRAW_SCORE = 0;
+const EVAL INFINITY_SCORE   = 50000;
+const EVAL CHECKMATE_SCORE  = 32767;
+const EVAL TBBASE_SCORE     = 22767;
+const EVAL DRAW_SCORE       = 0;
 
 struct Pair
 {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.3.1-b2";
+const std::string VERSION = "2.3.1-b3";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;


### PR DESCRIPTION
```
tc=all/10+0.1
os=linux
hash=16
Score of Igel 2.3.1-b3 64 POPCNT vs Igel 2.3.1-b2 64 POPCNT: 1026 - 810 - 1976  [0.528] 3812
Elo difference: 19.71 +/- 7.64

tc=40/102
os=windows
hash=256
Rank Name                          Elo     +/-   Games   Score   Draws
   0 Igel 2.3.1-b3 64 POPCNT       -48      18    1000   43.1%   31.4%
   1 Stockfish 10 64 POPCNT        512     122     100   95.0%   10.0%
   2 Xiphos 0.6 BMI2               330      72     100   87.0%   24.0%
   3 Andscacs 0.95                 177      55     100   73.5%   39.0%
   4 RubiChess 1.6                 147      52     100   70.0%   44.0%
   5 Strelka 5.5 x64               119      57     100   66.5%   35.0%
   6 Vajolet2 2.8.0                 63      51     100   59.0%   44.0%
   7 Pedone 1.9                     10      54     100   51.5%   39.0%
   8 Winter 0.7 BMI2               -96      55     100   36.5%   37.0%
   9 zurichess neuchatel          -225      64     100   21.5%   29.0%
  10 GreKo 2018.08                -413     101     100    8.5%   13.0%
Finished match
```