### PR TITLE
Igel 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ script:
       - pyenv versions
       - if [ "$TRAVIS_OS_NAME" == "linux" ]; then pyenv global 3.7 ; fi
       - cmake -D_BTYPE=POPCNT .
-      - make -j2
+      - make -j
       - cmake -D_MAKE_UNIT_TEST=UNIT_TEST -D_BTYPE=POPCNT .
-      - make -j2
+      - make -j
       - cd tests
       - pip install --upgrade pip
       - pip --version

--- a/history.txt
+++ b/history.txt
@@ -1,7 +1,33 @@
 Igel chess engine
 
 (c) 2002-2018 Vladimir Medvedev <vrm@bk.ru>
-(c) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+(c) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+
+Igel 2.3.1
+-------------
+14-Jan-2020
+
+- Re-write the root search routine
+- Re-write aspiration loop with a smaller aspiration window
+- Do not cutoff qsearch on pv moves in qsearch
+- Handle repetitions at the qsearch entance
+- More strict pruning conditions for quiet moves
+- Proper way to pass position to child threads in SMP mode to handle repetitions
+- Unified condition to killer moves as non-tactical moves
+- Perft tests for six different positions
+
+Igel 2.3.0
+-------------
+01-Jan-2020
+
+- Fix issue when reductions in LMR could lead to directly qsearch
+- Rename uci option 'Level' into 'Skill Level'
+- Do not apply razoring when in check
+- Do not apply 'improving' factor when in check
+- Do not prune quiets at root
+- Fetch history only when a quiet move is detected
+- Improve branching factor and apply LMR more aggressively
+- Fix compilaton issue with clang/gcc9 compiler
 
 Igel 2.2.1
 -------------

--- a/src/bitboards.cpp
+++ b/src/bitboards.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/bitboards.h
+++ b/src/bitboards.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/eval.h
+++ b/src/eval.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/eval_params.cpp
+++ b/src/eval_params.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/eval_params.h
+++ b/src/eval_params.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2019-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/history.h
+++ b/src/history.h
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2019-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/moveeval.cpp
+++ b/src/moveeval.cpp
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2019-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/moveeval.h
+++ b/src/moveeval.h
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2019-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/moves.cpp
+++ b/src/moves.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/moves.h
+++ b/src/moves.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/notation.cpp
+++ b/src/notation.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/notation.h
+++ b/src/notation.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/position.h
+++ b/src/position.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by
@@ -131,131 +131,6 @@ bool Search::checkLimits()
 void Search::setPosition(Position & pos)
 {
     m_position = pos;
-}
-
-EVAL Search::searchRoot(EVAL alpha, EVAL beta, int depth)
-{
-    int ply = 0;
-    m_pvSize[ply] = 0;
-    assert(depth > 0);
-    Move hashMove = 0;
-
-    int legalMoves = 0;
-    Move bestMove = 0;
-    U8 type = HASH_ALPHA;
-    auto inCheck = m_position.InCheck();
-    auto rootNode = depth == 1;
-
-    /*TEntry hEntry;
-
-    if (ProbeHash(hEntry))
-        hashMove = hEntry.move();*/
-
-    if (m_pv[0][0])
-        hashMove = m_pv[0][0];
-
-    MoveList& mvlist = m_lists[ply];
-
-    if (inCheck)
-        GenMovesInCheck(m_position, mvlist);
-    else
-        GenAllMoves(m_position, mvlist);
-
-    MoveEval::sortMoves(this, mvlist, hashMove, ply);
-    auto mvSize = mvlist.Size();
-
-    //
-    //  Different move ordering for lazy smp threads
-    //
-
-    if (!m_principalSearcher && depth == 1 && mvSize >= 2) {
-        int j = 0;
-        for (size_t i = mvSize - 1; i > 0; --i) {
-            mvlist.Swap(i, j++);
-        }
-    }
-
-    std::vector<Move> quietMoves;
-
-    for (size_t i = 0; i < mvSize; ++i) {
-
-        if (!rootNode && checkLimits())
-            return -INFINITY_SCORE;
-
-        auto onPV = (beta - alpha) > 1;
-        //m_time.adjust(onPV, depth, alpha);
-
-        auto mv = MoveEval::getNextBest(mvlist, i);
-        auto lastMove = m_position.LastMove();
-
-        if (m_position.MakeMove(mv)) {
-            History::HistoryHeuristics history{};
-
-            if (!MoveEval::isTacticalMove(mv)) {
-                quietMoves.emplace_back(mv);
-                History::fetchHistory(this, mv, ply, history);
-            }
-
-            ++m_nodes;
-            ++legalMoves;
-            m_moveStack[ply] = mv;
-            m_pieceStack[ply] = mv.Piece();
-
-            if ((m_principalSearcher) && ((GetProcTime() - m_t0) > 2000))
-                cout << "info depth " << depth << " currmove " << MoveToStrLong(mv) << " currmovenumber " << legalMoves << endl;
-
-            int newDepth = depth - 1;
-
-            //
-            //   EXTENSIONS
-            //
-
-            newDepth += extensionRequired(mv, lastMove, inCheck, ply, onPV, quietMoves.size(), history.cmhistory, history.fmhistory);
-
-            EVAL e;
-            if (legalMoves == 1)
-                e = -abSearch(-beta, -alpha, newDepth, ply + 1, false, true, true);
-            else
-            {
-                e = -abSearch(-alpha - 1, -alpha, newDepth, ply + 1, false, true, true);
-                if (e > alpha && e < beta)
-                    e = -abSearch(-beta, -alpha, newDepth, ply + 1, false, true, true);
-            }
-
-            m_position.UnmakeMove();
-
-            if (m_flags & SEARCH_TERMINATED)
-                return -INFINITY_SCORE;
-
-            if (e > alpha) {
-                alpha = e;
-                bestMove = mv;
-                type = HASH_EXACT;
-
-                m_pv[ply][0] = mv;
-                memcpy(m_pv[ply] + 1, m_pv[ply + 1], m_pvSize[ply + 1] * sizeof(Move));
-                m_pvSize[ply] = 1 + m_pvSize[ply + 1];
-                History::updateHistory(this, quietMoves, ply, depth * depth);
-            }
-
-            if (alpha >= beta) {
-                type = HASH_BETA;
-                if (!MoveEval::isTacticalMove(mv))
-                    History::setKillerMove(this, mv, ply);
-                break;
-            }
-        }
-    }
-
-    if (legalMoves == 0) {
-        if (inCheck)
-            alpha = -CHECKMATE_SCORE + ply;
-        else
-            alpha = DRAW_SCORE;
-    }
-
-    TTable::instance().record(bestMove, alpha, depth, ply, type, m_position.Hash());
-    return alpha;
 }
 
 EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bool pruneMoves, bool rootNode/*, Move skipMove = 0*/)
@@ -1235,7 +1110,6 @@ void Search::startSearch(Time time, int depth, EVAL alpha, EVAL beta, bool ponde
         //  Make a search
         //
 
-        //m_score = searchRoot(alpha, beta, m_depth);
         m_score = abSearch(alpha, beta, m_depth, 0, false, false, true);
 
         //
@@ -1342,9 +1216,6 @@ void Search::startSearch(Time time, int depth, EVAL alpha, EVAL beta, bool ponde
         if (dt > 1000)
             nps = 1000 * sumNodes / dt;
 
-        if (m_principalSearcher && nps)
-            cout << "info depth " << m_depth << " time " << dt << " nodes " << sumNodes << " nps " << nps << endl;
-
         if (m_time.getTimeMode() == Time::TimeControl::TimeLimit && dt >= m_time.getSoftLimit()) {
             m_flags |= TERMINATED_BY_LIMIT;
 
@@ -1378,10 +1249,8 @@ void Search::startSearch(Time time, int depth, EVAL alpha, EVAL beta, bool ponde
 
     waitUntilCompletion();
 
-    if (m_principalSearcher) {
-        printPV(m_position, m_depth, m_selDepth, m_score, m_pv[0], m_pvSize[0], m_best, sumNodes, sumHits, nps);
+    if (m_principalSearcher)
         printBestMove(this, m_position, m_best, ponder);
-    }
 }
 
 void Search::setPonderHit()

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -354,8 +354,19 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         GenAllMoves(m_position, mvlist);
 
     MoveEval::sortMoves(this, mvlist, hashMove, ply);
-
     auto mvSize = mvlist.Size();
+
+    //
+    //  Different move ordering for lazy smp threads
+    //
+
+    if (!m_principalSearcher && depth == 1 && mvSize >= 2) {
+        int j = 0;
+        for (size_t i = mvSize - 1; i > 0; --i) {
+            mvlist.Swap(i, j++);
+        }
+    }
+
     std::vector<Move> quietMoves;
     auto improving = !inCheck && ply >= 2 && staticEval > m_evalStack[ply - 2];
     m_killerMoves[ply + 1][0] = m_killerMoves[ply + 1][1] = 0;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -240,7 +240,7 @@ EVAL Search::searchRoot(EVAL alpha, EVAL beta, int depth)
 
             if (alpha >= beta) {
                 type = HASH_BETA;
-                if (!mv.Captured() && !mv.Promotion())
+                if (!MoveEval::isTacticalMove(mv))
                     History::setKillerMove(this, mv, ply);
                 break;
             }
@@ -622,7 +622,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             if (alpha >= beta)
             {
                 type = HASH_BETA;
-                if (!mv.Captured())
+                if (!MoveEval::isTacticalMove(mv))
                     History::setKillerMove(this, mv, ply);
                 break;
             }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -263,13 +263,11 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
     m_pvSize[ply] = 0;
     m_selDepth = std::max(ply, m_selDepth);
 
-    auto inCheck = m_position.InCheck();
-
     //
     //   qsearch
     //
 
-    if (!inCheck && depth <= 0 && m_level > MEDIUM_LEVEL)
+    if (depth <= 0 && m_level > MEDIUM_LEVEL)
         return qSearch(alpha, beta, ply);
 
     ++m_nodes;
@@ -280,7 +278,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             return -INFINITY_SCORE;
 
         if ((ply > MAX_PLY - 2) || m_position.Repetitions() >= 2)
-            return ((ply > MAX_PLY - 2) && !inCheck) ? m_evaluator->evaluate(m_position) : DRAW_SCORE;
+            return ((ply > MAX_PLY - 2) && !m_position.InCheck()) ? m_evaluator->evaluate(m_position) : DRAW_SCORE;
 
         //
         // mate distance pruning
@@ -383,7 +381,15 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         }
     }
 
-    EVAL staticEval = m_evalStack[ply] = m_evaluator->evaluate(m_position);
+    EVAL staticEval;
+    auto inCheck = m_position.InCheck();
+
+    if (inCheck)
+        staticEval = -CHECKMATE_SCORE + ply;
+    else
+        staticEval = m_evaluator->evaluate(m_position);
+
+    m_evalStack[ply] = staticEval;
 
     if (pruneMoves && !isCheckMateScore(beta) && !inCheck) {
 
@@ -466,7 +472,8 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
     }
 
     int legalMoves = 0;
-    Move bestMove = 0;
+    Move bestMove = hashMove;
+    EVAL bestScore = -CHECKMATE_SCORE + ply;
     U8 type = HASH_ALPHA;
 
     MoveList& mvlist = m_lists[ply];
@@ -604,42 +611,44 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             if (m_flags & SEARCH_TERMINATED)
                 return -INFINITY_SCORE;
 
-            if (e > alpha)
-            {
-                alpha = e;
-                bestMove = mv;
-                type = HASH_EXACT;
+            if (e > bestScore) {
+                bestScore = e;
+                if (e > alpha) {
+                    alpha = e;
+                    bestMove = mv;
+                    type = HASH_EXACT;
 
-                m_pv[ply][0] = mv;
-                memcpy(m_pv[ply] + 1, m_pv[ply + 1], m_pvSize[ply + 1] * sizeof(Move));
-                m_pvSize[ply] = 1 + m_pvSize[ply + 1];
-                History::updateHistory(this, quietMoves, ply, depth * depth);
-            }
+                    m_pv[ply][0] = mv;
+                    memcpy(m_pv[ply] + 1, m_pv[ply + 1], m_pvSize[ply + 1] * sizeof(Move));
+                    m_pvSize[ply] = 1 + m_pvSize[ply + 1];
 
-            if (alpha >= beta)
-            {
-                type = HASH_BETA;
-                if (!MoveEval::isTacticalMove(mv))
-                    History::setKillerMove(this, mv, ply);
-                break;
+                    if (alpha >= beta) {
+                        type = HASH_BETA;
+                        if (!MoveEval::isTacticalMove(mv)) {
+                            History::updateHistory(this, quietMoves, ply, depth * depth);
+                            History::setKillerMove(this, mv, ply);
+                        }
+                        break;
+                    }
+                }
             }
         }
     }
 
     if (legalMoves == 0) {
         if (inCheck)
-            alpha = -CHECKMATE_SCORE + ply;
+            bestScore = -CHECKMATE_SCORE + ply;
         else
-            alpha = DRAW_SCORE;
+            bestScore = DRAW_SCORE;
     }
     else
     {
         if (m_position.Fifty() >= 100)
-            alpha = DRAW_SCORE;
+            bestScore = DRAW_SCORE;
     }
 
-    TTable::instance().record(bestMove, alpha, depth, ply, type, m_position.Hash());
-    return alpha;
+    TTable::instance().record(bestMove, bestScore, depth, ply, type, m_position.Hash());
+    return bestScore;
 }
 
 EVAL Search::qSearch(EVAL alpha, EVAL beta, int ply)
@@ -1226,7 +1235,8 @@ void Search::startSearch(Time time, int depth, EVAL alpha, EVAL beta, bool ponde
         //  Make a search
         //
 
-        m_score = searchRoot(alpha, beta, m_depth);
+        //m_score = searchRoot(alpha, beta, m_depth);
+        m_score = abSearch(alpha, beta, m_depth, 0, false, false, true);
 
         //
         //  Validate if we received a ponderhit

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -923,7 +923,6 @@ void Search::startWorkerThreads(Time time)
         m_threadParams[i].m_nodes = 0;
         m_threadParams[i].m_selDepth = 0;
         m_threadParams[i].m_tbHits = 0;
-        m_threadParams[i].m_position.SetFEN(m_position.FEN());
         m_threadParams[i].setTime(time);
         m_threadParams[i].setLevel(m_level);
         m_threadParams[i].m_t0 = m_t0;
@@ -1332,4 +1331,30 @@ void Search::releaseHelperThreads()
             m_threads[i].join();
         }
     }
+}
+
+bool Search::setFEN(const std::string& fen)
+{
+    for (unsigned int i = 0; i < m_thc; ++i)
+        m_threadParams[i].m_position.SetFEN(fen);
+
+    return m_position.SetFEN(fen);
+}
+
+bool Search::setInitialPosition()
+{
+    for (unsigned int i = 0; i < m_thc; ++i)
+        m_threadParams[i].m_position.SetInitial();
+
+    m_position.SetInitial();
+
+    return true;
+}
+
+bool Search::makeMove(Move mv)
+{
+    for (unsigned int i = 0; i < m_thc; ++i)
+        m_threadParams[i].m_position.MakeMove(mv);
+
+    return m_position.MakeMove(mv);
 }

--- a/src/search.h
+++ b/src/search.h
@@ -76,6 +76,9 @@ public:
     void stopPrincipalSearch();
     void isReady();
     void setLevel(int level);
+    bool setFEN(const std::string& fen);
+    bool setInitialPosition();
+    bool makeMove(Move mv);
 
 private:
     void startWorkerThreads(Time time);

--- a/src/search.h
+++ b/src/search.h
@@ -64,7 +64,7 @@ public:
     Search& operator=(const Search&) = delete;
 
 public:
-    void startSearch(Time time, int depth, EVAL alpha, EVAL beta, bool ponder);
+    void startSearch(Time time, int depth, bool ponder);
     void clearHistory();
     void clearKillers();
     void clearStacks();
@@ -140,8 +140,6 @@ private:
     std::unique_ptr<Search[]> m_threadParams;
     std::condition_variable m_lazycv;
     volatile int m_lazyDepth;
-    int m_lazyAlpha;
-    int m_lazyBeta;
     Move m_best;
     volatile bool m_smpThreadExit;
     bool m_lazyPonder;

--- a/src/search.h
+++ b/src/search.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by
@@ -83,7 +83,6 @@ private:
     void lazySmpSearcher();
     void indicateWorkersStop();
     Move tableBaseRootSearch();
-    EVAL searchRoot(EVAL alpha, EVAL beta, int depth);
     EVAL abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bool pruneMoves, bool rootNode/*, Move skipMove = 0*/);
     EVAL qSearch(EVAL alpha, EVAL beta, int ply);
     int extensionRequired(Move mv, Move lastMove, bool inCheck, int ply, bool onPV, size_t quietMoves, int cmhistory, int fmhistory);

--- a/src/search.h
+++ b/src/search.h
@@ -107,7 +107,6 @@ private:
     U32 m_t0;
     volatile U8 m_flags;
     int m_depth;
-    int m_completedDepth;
     int m_syzygyDepth;
     int m_selDepth;
     int m_iterPVSize;
@@ -143,7 +142,6 @@ private:
     volatile int m_lazyDepth;
     int m_lazyAlpha;
     int m_lazyBeta;
-    EVAL m_score;
     Move m_best;
     volatile bool m_smpThreadExit;
     bool m_lazyPonder;

--- a/src/search.h
+++ b/src/search.h
@@ -50,6 +50,8 @@ const U8 MODE_SILENT  = 0x10;
 #define isCheckMateScore(score)        ((score) <= -CHECKMATE_SCORE + 50|| \
                                         (score) >=  CHECKMATE_SCORE - 50)
 
+#define MATED_IN_MAX (MAX_PLY - CHECKMATE_SCORE)
+
 class Search
 {
     friend class History;

--- a/src/texel.cpp
+++ b/src/texel.cpp
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2019-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/texel.h
+++ b/src/texel.h
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2019-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -168,9 +168,6 @@ bool Time::evaluate()
 
 bool Time::adjust(bool onPv, int depth, EVAL score)
 {
-    if (abs(score) >= INFINITY_SCORE)
-        return false;
-
     //
     //  Do not bother with shallow depth
     //
@@ -223,7 +220,7 @@ bool Time::adjust(bool onPv, int depth, EVAL score)
 void Time::resetAdjustment()
 {
     m_onPv  = false;
-    m_prevScore = -INFINITY_SCORE;
+    m_prevScore = DRAW_SCORE;
 }
 
 U32 Time::getSoftLimit()

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -160,8 +160,8 @@ bool Time::evaluate()
     //  Normal time control
     //
 
-    m_hardLimit = (m_remainingTime / 4) + (m_increment / 2) + getEnemyLowTimeBonus();
-    m_softLimit = m_hardLimit / 12;
+    m_hardLimit = (m_remainingTime / 10) + (m_increment / 2) + getEnemyLowTimeBonus();
+    m_softLimit = m_hardLimit / 4;
 
     return true;
 }

--- a/src/time.h
+++ b/src/time.h
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -3,7 +3,7 @@
 *
 *  Copyright (C) 1990-1992 Robert Hyatt and Tim Mann (crafty authors): lockless design of tt
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author): general logic of tt
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -36,13 +36,8 @@ TTable & TTable::instance()
 
 bool TTable::record(Move mv, EVAL score, U8 depth, int ply, U8 type, U64 hash0)
 {
-    if (abs(score) >= INFINITY_SCORE)
-        return false;
-
     assert(m_hash);
     assert(m_hashSize);
-    assert(score <= INFINITY_SCORE);
-    assert(score >= -INFINITY_SCORE);
 
     size_t index = hash0 % m_hashSize;
     TEntry & entry = m_hash[index];

--- a/src/tt.h
+++ b/src/tt.h
@@ -3,7 +3,7 @@
 *
 *  Copyright (C) 1990-1992 Robert Hyatt and Tim Mann (crafty authors): lockless design of tt
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author): general logic of tt
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/types.h
+++ b/src/types.h
@@ -129,7 +129,6 @@ enum
     DIR_DR = 7
 };
 
-const EVAL INFINITY_SCORE   = 50000;
 const EVAL CHECKMATE_SCORE  = 32767;
 const EVAL TBBASE_SCORE     = 22767;
 const EVAL DRAW_SCORE       = 0;

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/types.h
+++ b/src/types.h
@@ -129,10 +129,10 @@ enum
     DIR_DR = 7
 };
 
-const EVAL INFINITY_SCORE  = 50000;
-const EVAL CHECKMATE_SCORE = 32767;
-const EVAL TBBASE_SCORE    = 22767;
-const EVAL DRAW_SCORE = 0;
+const EVAL INFINITY_SCORE   = 50000;
+const EVAL CHECKMATE_SCORE  = 32767;
+const EVAL TBBASE_SCORE     = 22767;
+const EVAL DRAW_SCORE       = 0;
 
 struct Pair
 {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.3.1-b1";
+const std::string VERSION = "2.3.1-b2";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.3.1-b3";
+const std::string VERSION = "2.3.1-c1";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.3.0";
+const std::string VERSION = "2.3.1-a1";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2019-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.3.1-c2";
+const std::string VERSION = "2.3.1";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.3.1-a1";
+const std::string VERSION = "2.3.1-a2";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.3.1-a3";
+const std::string VERSION = "2.3.1-b1";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;
@@ -204,10 +204,10 @@ void Uci::onPosition(commandParams params)
                 fen += " ";
             fen += params[i];
         }
-        m_searcher.m_position.SetFEN(fen);
+        m_searcher.setFEN(fen);
     }
     else if (params[1] == "startpos") {
-        m_searcher.m_position.SetInitial();
+        m_searcher.setInitialPosition();
         for (size_t i = 2; i < params.size(); ++i) {
             if (params[i] == "moves")
             {
@@ -220,7 +220,7 @@ void Uci::onPosition(commandParams params)
     if (movesTag) {
         for (size_t i = movesTag + 1; i < params.size(); ++i) {
             Move mv = StrToMove(params[i], m_searcher.m_position);
-            m_searcher.m_position.MakeMove(mv);
+            m_searcher.makeMove(mv);
         }
     }
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.3.1-c1";
+const std::string VERSION = "2.3.1-c2";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.3.1-b2";
+const std::string VERSION = "2.3.1-b3";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.3.1-a2";
+const std::string VERSION = "2.3.1-a3";
 
 const int MIN_HASH_SIZE = 1;
 const int MAX_HASH_SIZE = 1048576;

--- a/src/uci.h
+++ b/src/uci.h
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2019-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/unit/test_tt.cpp
+++ b/src/unit/test_tt.cpp
@@ -83,7 +83,7 @@ TEST(TranspositionTableEntryScoreTest, Positive)
 
     EXPECT_EQ(0, te.score());
 
-    for (auto i = -INFINITY_SCORE; i <= INFINITY_SCORE; ++i)
+    for (auto i = -CHECKMATE_SCORE + 128; i <= CHECKMATE_SCORE + 128; ++i)
     {
         te.store(0, i, 0, 0, 0, 0);
         EXPECT_EQ(i, te.score());
@@ -195,26 +195,26 @@ TEST(TranspositionTableEntryCompositeTest, Positive)
     EXPECT_EQ(1, te.depth());
     EXPECT_EQ(1, te.score());
 
-    te.store(16777215, INFINITY_SCORE, 1, 1, 1, 1);
+    te.store(16777215, CHECKMATE_SCORE, 1, 1, 1, 1);
     EXPECT_EQ(1, te.age());
     EXPECT_EQ(1, te.type());
     EXPECT_EQ(16777215, te.move());
     EXPECT_EQ(1, te.depth());
-    EXPECT_EQ(INFINITY_SCORE, te.score());
+    EXPECT_EQ(CHECKMATE_SCORE, te.score());
 
-    te.store(16777215, -INFINITY_SCORE, 1, 1, 1, 1);
+    te.store(16777215, -CHECKMATE_SCORE, 1, 1, 1, 1);
     EXPECT_EQ(1, te.age());
     EXPECT_EQ(1, te.type());
     EXPECT_EQ(16777215, te.move());
     EXPECT_EQ(1, te.depth());
-    EXPECT_EQ(-INFINITY_SCORE, te.score());
+    EXPECT_EQ(-CHECKMATE_SCORE, te.score());
 
     // move range
     for (auto i = 0; i <= 16777215; ++i)
     {
-        te.store(i, INFINITY_SCORE, 1, 1, 1, 1);
+        te.store(i, CHECKMATE_SCORE, 1, 1, 1, 1);
         EXPECT_EQ(i, te.move());
-        EXPECT_EQ(INFINITY_SCORE, te.score());
+        EXPECT_EQ(CHECKMATE_SCORE, te.score());
         EXPECT_EQ(1, te.depth());
         EXPECT_EQ(1, te.age());
         EXPECT_EQ(1, te.type());
@@ -223,16 +223,16 @@ TEST(TranspositionTableEntryCompositeTest, Positive)
     // depth range
     for (auto i = 0; i < 255; ++i)
     {
-        te.store(16777215, -INFINITY_SCORE, i, 1, 1, 1);
+        te.store(16777215, -CHECKMATE_SCORE, i, 1, 1, 1);
         EXPECT_EQ(i, te.depth());
         EXPECT_EQ(1, te.age());
         EXPECT_EQ(1, te.type());
         EXPECT_EQ(16777215, te.move());
-        EXPECT_EQ(-INFINITY_SCORE, te.score());
+        EXPECT_EQ(-CHECKMATE_SCORE, te.score());
     }
 
     // score range
-    for (auto i = -INFINITY_SCORE; i <= INFINITY_SCORE; ++i)
+    for (auto i = -CHECKMATE_SCORE + 128; i <= CHECKMATE_SCORE + 128; ++i)
     {
         te.store(16777215, i, 1, 1, 1, 1);
         EXPECT_EQ(i, te.score());

--- a/src/unit/testmoves.cpp
+++ b/src/unit/testmoves.cpp
@@ -34,6 +34,11 @@ NODES Perft(Position & pos, int depth)
     NODES total = 0;
     MoveList mvlist;
 
+    if (pos.InCheck())
+        GenMovesInCheck(pos, mvlist);
+    else
+        GenAllMoves(pos, mvlist);
+
     GenAllMoves(pos, mvlist);
 
     auto mvSize = mvlist.Size();
@@ -51,7 +56,7 @@ NODES Perft(Position & pos, int depth)
     return total;
 }
 
-TEST(MoveGen, Positive)
+TEST(MoveGenPos_1, Positive)
 {
     std::unique_ptr<Position> pos(new Position);
 
@@ -65,6 +70,87 @@ TEST(MoveGen, Positive)
     EXPECT_EQ(197281, Perft(*pos.get(), 4));
     EXPECT_EQ(4865609, Perft(*pos.get(), 5));
     EXPECT_EQ(119060324, Perft(*pos.get(), 6));
+    //EXPECT_EQ(3195901860, Perft(*pos.get(), 7));
+}
+
+TEST(MoveGenPos_2, Positive)
+{
+    std::unique_ptr<Position> pos(new Position);
+
+    EXPECT_EQ(true, pos->SetFEN("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -"));
+
+    // taken from https://chessprogramming.wikispaces.com/Perft%20Results
+    EXPECT_EQ(1, Perft(*pos.get(), 0));
+    EXPECT_EQ(48, Perft(*pos.get(), 1));
+    EXPECT_EQ(2039, Perft(*pos.get(), 2));
+    EXPECT_EQ(97862, Perft(*pos.get(), 3));
+    EXPECT_EQ(4085603, Perft(*pos.get(), 4));
+    EXPECT_EQ(193690690, Perft(*pos.get(), 5));
+    //EXPECT_EQ(8031647685, Perft(*pos.get(), 6));
+}
+
+TEST(MoveGenPos_3, Positive)
+{
+    std::unique_ptr<Position> pos(new Position);
+
+    EXPECT_EQ(true, pos->SetFEN("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - -"));
+
+    // taken from https://chessprogramming.wikispaces.com/Perft%20Results
+    EXPECT_EQ(1, Perft(*pos.get(), 0));
+    EXPECT_EQ(14, Perft(*pos.get(), 1));
+    EXPECT_EQ(191, Perft(*pos.get(), 2));
+    EXPECT_EQ(2812, Perft(*pos.get(), 3));
+    EXPECT_EQ(43238, Perft(*pos.get(), 4));
+    EXPECT_EQ(674624, Perft(*pos.get(), 5));
+    EXPECT_EQ(11030083, Perft(*pos.get(), 6));
+    EXPECT_EQ(178633661, Perft(*pos.get(), 7));
+}
+
+TEST(MoveGenPos_4, Positive)
+{
+    std::unique_ptr<Position> pos(new Position);
+
+    EXPECT_EQ(true, pos->SetFEN("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1"));
+
+    // taken from https://chessprogramming.wikispaces.com/Perft%20Results
+    EXPECT_EQ(1, Perft(*pos.get(), 0));
+    EXPECT_EQ(6, Perft(*pos.get(), 1));
+    EXPECT_EQ(264, Perft(*pos.get(), 2));
+    EXPECT_EQ(9467, Perft(*pos.get(), 3));
+    EXPECT_EQ(422333, Perft(*pos.get(), 4));
+    EXPECT_EQ(15833292, Perft(*pos.get(), 5));
+    //EXPECT_EQ(706045033, Perft(*pos.get(), 6));
+}
+
+TEST(MoveGenPos_5, Positive)
+{
+    std::unique_ptr<Position> pos(new Position);
+
+    EXPECT_EQ(true, pos->SetFEN("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8"));
+
+    // taken from https://chessprogramming.wikispaces.com/Perft%20Results
+    EXPECT_EQ(1, Perft(*pos.get(), 0));
+    EXPECT_EQ(44, Perft(*pos.get(), 1));
+    EXPECT_EQ(1486, Perft(*pos.get(), 2));
+    EXPECT_EQ(62379, Perft(*pos.get(), 3));
+    EXPECT_EQ(2103487, Perft(*pos.get(), 4));
+    EXPECT_EQ(89941194, Perft(*pos.get(), 5));
+}
+
+TEST(MoveGenPos_6, Positive)
+{
+    std::unique_ptr<Position> pos(new Position);
+
+    EXPECT_EQ(true, pos->SetFEN("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10"));
+
+    // taken from https://chessprogramming.wikispaces.com/Perft%20Results
+    EXPECT_EQ(1, Perft(*pos.get(), 0));
+    EXPECT_EQ(46, Perft(*pos.get(), 1));
+    EXPECT_EQ(2079, Perft(*pos.get(), 2));
+    EXPECT_EQ(89890, Perft(*pos.get(), 3));
+    EXPECT_EQ(3894594, Perft(*pos.get(), 4));
+    EXPECT_EQ(164075551, Perft(*pos.get(), 5));
+    //EXPECT_EQ(6923051137, Perft(*pos.get(), 6));
 }
 
 TEST(Move, Positive)

--- a/src/unit/testtime.cpp
+++ b/src/unit/testtime.cpp
@@ -79,13 +79,13 @@ TEST(Movetime, Positive)
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, true));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 100);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 100);
+    EXPECT_EQ(100, Time::instance().getHardLimit());
+    EXPECT_EQ(100, Time::instance().getSoftLimit());
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, false));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 100);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 100);
+    EXPECT_EQ(100, Time::instance().getHardLimit());
+    EXPECT_EQ(100, Time::instance().getSoftLimit());
 }
 
 TEST(Movetime, Negative)
@@ -97,13 +97,13 @@ TEST(Movetime, Negative)
 
     EXPECT_EQ(false, Time::instance().parseTime(cmd, true));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 1000);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1000);
+    EXPECT_EQ(1000, Time::instance().getHardLimit());
+    EXPECT_EQ(1000, Time::instance().getSoftLimit());
 
     EXPECT_EQ(false, Time::instance().parseTime(cmd, false));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 1000);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1000);
+    EXPECT_EQ(1000, Time::instance().getHardLimit());
+    EXPECT_EQ(1000, Time::instance().getSoftLimit());
 }
 
 TEST(MovesToGo, Positive)
@@ -120,13 +120,13 @@ TEST(MovesToGo, Positive)
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, true));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 2722);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == (2722 / 2));
+    EXPECT_EQ(2722, Time::instance().getHardLimit());
+    EXPECT_EQ(2722 / 2, Time::instance().getSoftLimit());
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, false));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 2722);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == (2722 / 2));
+    EXPECT_EQ(2722, Time::instance().getHardLimit());
+    EXPECT_EQ(2722 / 2, Time::instance().getSoftLimit());
 }
 
 TEST(MovesToGo, Negative)
@@ -142,13 +142,13 @@ TEST(MovesToGo, Negative)
 
     EXPECT_EQ(false, Time::instance().parseTime(cmd, true));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 1000);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1000);
+    EXPECT_EQ(1000, Time::instance().getHardLimit());
+    EXPECT_EQ(1000, Time::instance().getSoftLimit());
 
     EXPECT_EQ(false, Time::instance().parseTime(cmd, false));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 1000);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1000);
+    EXPECT_EQ(1000, Time::instance().getHardLimit());
+    EXPECT_EQ(1000, Time::instance().getSoftLimit());
 }
 
 TEST(MovesToGoIncrement, Positive)
@@ -171,8 +171,8 @@ TEST(MovesToGoIncrement, Positive)
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, true));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 6472);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == (6472 / 2));
+    EXPECT_EQ(6472, Time::instance().getHardLimit());
+    EXPECT_EQ(6472 / 2, Time::instance().getSoftLimit());
 }
 
 TEST(NormalControlNoIncrement, Positive)
@@ -187,13 +187,13 @@ TEST(NormalControlNoIncrement, Positive)
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, true));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 14975);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1247);
+    EXPECT_EQ(5990, Time::instance().getHardLimit());
+    EXPECT_EQ(1497, Time::instance().getSoftLimit());
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, false));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 14975);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1247);
+    EXPECT_EQ(5990, Time::instance().getHardLimit());
+    EXPECT_EQ(1497, Time::instance().getSoftLimit());
 }
 
 TEST(NormalControlNoIncrementEnemyHasMoreTime, Positive)
@@ -208,8 +208,8 @@ TEST(NormalControlNoIncrementEnemyHasMoreTime, Positive)
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, true));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 14975);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1247);
+    EXPECT_EQ(5990, Time::instance().getHardLimit());
+    EXPECT_EQ(1497, Time::instance().getSoftLimit());
 
     cmd.clear();
 
@@ -221,8 +221,8 @@ TEST(NormalControlNoIncrementEnemyHasMoreTime, Positive)
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, false));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 14975);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1247);
+    EXPECT_EQ(5990, Time::instance().getHardLimit());
+    EXPECT_EQ(1497, Time::instance().getSoftLimit());
 }
 
 TEST(NormalControlNoIncrementEnemyHasLessTime, Positive)
@@ -237,8 +237,8 @@ TEST(NormalControlNoIncrementEnemyHasLessTime, Positive)
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, true));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 15965);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1330);
+    EXPECT_EQ(6980, Time::instance().getHardLimit());
+    EXPECT_EQ(1745, Time::instance().getSoftLimit());
 
     cmd.clear();
     cmd.push_back("go");
@@ -249,8 +249,8 @@ TEST(NormalControlNoIncrementEnemyHasLessTime, Positive)
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, false));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 15965);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1330);
+    EXPECT_EQ(6980, Time::instance().getHardLimit());
+    EXPECT_EQ(1745, Time::instance().getSoftLimit());
 }
 
 TEST(NormalControlIncrement, Positive)
@@ -270,8 +270,8 @@ TEST(NormalControlIncrement, Positive)
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, true));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 15975);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1331);
+    EXPECT_EQ(6990, Time::instance().getHardLimit());
+    EXPECT_EQ(1747, Time::instance().getSoftLimit());
 
     cmd.clear();
     cmd.push_back("go");
@@ -287,8 +287,8 @@ TEST(NormalControlIncrement, Positive)
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, false));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 15475);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1289);
+    EXPECT_EQ(6490, Time::instance().getHardLimit());
+    EXPECT_EQ(1622, Time::instance().getSoftLimit());
 }
 
 TEST(NormalControlIncrementEnemyHasMoreTime, Positive)
@@ -308,8 +308,8 @@ TEST(NormalControlIncrementEnemyHasMoreTime, Positive)
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, true));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 15975);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1331);
+    EXPECT_EQ(6990, Time::instance().getHardLimit());
+    EXPECT_EQ(1747, Time::instance().getSoftLimit());
 
     cmd.clear();
 
@@ -326,8 +326,8 @@ TEST(NormalControlIncrementEnemyHasMoreTime, Positive)
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, false));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 15475);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1289);
+    EXPECT_EQ(6490, Time::instance().getHardLimit());
+    EXPECT_EQ(1622, Time::instance().getSoftLimit());
 }
 
 TEST(NormalControlIncrementEnemyHasLessTime, Positive)
@@ -347,8 +347,8 @@ TEST(NormalControlIncrementEnemyHasLessTime, Positive)
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, true));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 17965);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1497);
+    EXPECT_EQ(8980, Time::instance().getHardLimit());
+    EXPECT_EQ(2245, Time::instance().getSoftLimit());
 
     cmd.clear();
 
@@ -365,8 +365,8 @@ TEST(NormalControlIncrementEnemyHasLessTime, Positive)
 
     EXPECT_EQ(true, Time::instance().parseTime(cmd, false));
     EXPECT_EQ(Time::TimeControl::TimeLimit, Time::instance().getTimeMode());
-    EXPECT_EQ(true, Time::instance().getHardLimit() == 18465);
-    EXPECT_EQ(true, Time::instance().getSoftLimit() == 1538);
+    EXPECT_EQ(9480, Time::instance().getHardLimit());
+    EXPECT_EQ(2370, Time::instance().getSoftLimit());
 }
 
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/tests/ci.py
+++ b/tests/ci.py
@@ -1,7 +1,7 @@
 #
 #  Igel - a UCI chess playing engine derived from GreKo 2018.01
 #
-#  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+#  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 #
 #  Igel is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/epd_test.py
+++ b/tests/epd_test.py
@@ -2,7 +2,7 @@
 #  Igel - a UCI chess playing engine derived from GreKo 2018.01
 #
 #  Copyright (C) 2015 Niklas Fiekas
-#  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+#  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 #
 #  Igel is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/go_infinite_test.py
+++ b/tests/go_infinite_test.py
@@ -1,7 +1,7 @@
 #
 #  Igel - a UCI chess playing engine derived from GreKo 2018.01
 #
-#  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+#  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 #
 #  Igel is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/mate_in_n.py
+++ b/tests/mate_in_n.py
@@ -1,7 +1,7 @@
 #
 #  Igel - a UCI chess playing engine derived from GreKo 2018.01
 #
-#  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+#  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 #
 #  Igel is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,7 +1,7 @@
 #
 #  Igel - a UCI chess playing engine derived from GreKo 2018.01
 #
-#  Copyright (C) 2018-2019 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+#  Copyright (C) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 #
 #  Igel is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Igel 2.3.1
-------------
14-Jan-2020

- Re-write the root search routine
- Re-write aspiration loop with a smaller aspiration window
- Do not cutoff qsearch on pv moves in qsearch
- Handle repetitions at the qsearch entance
- More strict pruning conditions for quiet moves
- Proper way to pass position to child threads in SMP mode to handle repetitions
- Unified condition to killer moves as non-tactical moves
- Perft tests for six different positions