### PR TITLE
2.9-dev-0: avoid custom scaling

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -147,10 +147,6 @@ EVAL Evaluator::evaluate(Position & pos)
 
 #if defined(EVAL_NNUE)
     nnueEval = static_cast<EVAL>(Eval::NNUE::evaluate(pos));
-
-    if (abs(nnueEval) < VAL_Q)
-        nnueEval = nnueEval * 2;
-
     return nnueEval + Tempo;
 #endif
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.8.0";//"2.8-dev-3";
+const std::string VERSION = "2.9-dev-0";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/7985/

ELO   | 50.54 +- 13.29 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 5.00]
Games | N: 900 W: 221 L: 91 D: 588

http://chess.grantnet.us/test/7984/

ELO   | 51.25 +- 15.13 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 956 W: 294 L: 154 D: 508

Regression run against Night Nurse:

http://chess.grantnet.us/test/7986/

ELO   | -5.18 +- 6.61 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 0.00 (-2.94, 2.94) [0.00, 0.00]
Games | N: 4762 W: 1034 L: 1105 D: 2623