### PR TITLE
2.9-dev-3: nnue scale eval based on material

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -133,7 +133,9 @@ EVAL Evaluator::evaluate(Position & pos)
     PawnHashEntry* ps;
     U64 occ;
 #if defined(EVAL_NNUE)
-    EVAL nnueEval;
+    EVAL nnueEval,
+         pawns,
+         material;
 #endif
 
     auto score = pos.Score();
@@ -147,7 +149,9 @@ EVAL Evaluator::evaluate(Position & pos)
 
 #if defined(EVAL_NNUE)
     nnueEval = static_cast<EVAL>(Eval::NNUE::evaluate(pos));
-    return nnueEval + Tempo;
+    pawns    = pos.Count(PAWN | WHITE) + pos.Count(PAWN | BLACK);
+    material = pos.nonPawnMaterial() + (pawns * VAL_P);
+    return nnueEval * (600 + material / 32) / 1024 + Tempo;
 #endif
 
     memset(m_pieceAttacks,         0, sizeof(m_pieceAttacks));

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.9-dev-2";
+const std::string VERSION = "2.9-dev-3";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
Network: ign-0-9b1937cc

http://chess.grantnet.us/test/9064/

ELO   | 8.64 +- 5.52 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6716 W: 1569 L: 1402 D: 3745

http://chess.grantnet.us/test/9065/

ELO   | 7.33 +- 4.45 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6924 W: 1099 L: 953 D: 4872