### PR TITLE
3.0-dev-0: fix in check extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -428,14 +428,14 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
                 quietMoves.emplace_back(mv);
             }
 
-            m_moveStack[ply] = mv;
+            m_moveStack[ply]  = mv;
             m_pieceStack[ply] = mv.Piece();
 
             //
             //   extensions
             //
 
-            newDepth += extensionRequired(mv, lastMove, inCheck, ply, onPV, quietMoves.size(), history.cmhistory, history.fmhistory);
+            newDepth += extensionRequired(mv, lastMove, m_position.InCheck(), ply, onPV, quietMoves.size(), history.cmhistory, history.fmhistory);
 
             EVAL e;
             if (legalMoves == 1)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "2.9.0"; //"2.9-dev-3";
+const std::string VERSION = "3.0-dev-0";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/9163/

ELO   | 12.34 +- 6.84 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4280 W: 1002 L: 850 D: 2428

http://chess.grantnet.us/test/9164/

ELO   | 0.72 +- 1.27 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | -3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 82000 W: 11894 L: 11725 D: 58381