### PR TITLE
correct singular extension condition (feedback from ChizhovVadim)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -408,7 +408,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         //  singular extensions
         //
 
-        if (depth >= 8 && !skipMove && hashMove == mv && !rootNode && !isCheckMateScore(hEntry.m_data.score) && hEntry.m_data.type == HASH_BETA && hEntry.m_data.depth >= depth - 3) {
+        if (depth >= 8 && !skipMove && hashMove == mv && !rootNode && !isCheckMateScore(hEntry.m_data.score) && (hEntry.m_data.type == HASH_BETA || hEntry.m_data.type == HASH_EXACT) && hEntry.m_data.depth >= depth - 3) {
             auto betaCut = hEntry.m_data.score - depth;
             auto score = abSearch(betaCut - 1, betaCut, depth / 2, ply + 1, false, false, mv);
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-1";
+const std::string VERSION = "3.0-dev-2";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
ChizhovVadim (author of CounterGo) suggested to modify singular extension condition in ticket https://github.com/vshcherbyna/igel/issues/202

http://chess.grantnet.us/test/10113/

```
ELO   | 2.72 +- 2.13 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 43598 W: 9486 L: 9145 D: 24967
```

http://chess.grantnet.us/test/10116/

```
ELO   | 6.84 +- 4.25 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7420 W: 1146 L: 1000 D: 5274
```