### PR TITLE
3.0-dev-3: less aggressive time usage in sudden death tc

### DIFF
--- a/src/time.cpp
+++ b/src/time.cpp
@@ -162,7 +162,7 @@ bool Time::evaluate()
 
     auto bonus  = m_increment ? getEnemyLowTimeBonus() : 0;
     m_hardLimit = (m_remainingTime / 12) + (m_increment / 2) + bonus;
-    m_softLimit = m_hardLimit / 4;
+    m_softLimit = m_increment ? (m_hardLimit / 4) : (m_hardLimit / 5);
 
     return true;
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-2";
+const std::string VERSION = "3.0-dev-3";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10152/

ELO   | 16.18 +- 8.22 (95%)
SPRT  | 10.0+0.0s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3352 W: 897 L: 741 D: 1714

http://chess.grantnet.us/test/10153/

ELO   | 20.74 +- 8.33 (95%)
SPRT  | 60.0+0.0s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2214 W: 434 L: 302 D: 1478

http://chess.grantnet.us/test/10157/

ELO   | 0.45 +- 1.94 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 50496 W: 10445 L: 10379 D: 29672