### PR TITLE
3.0-dev-3: null move prunning tunning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -287,7 +287,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         //
 
         if (!isNull && depth >= 2 && m_position.NonPawnMaterial() && bestScore >= beta) {
-            int R = 4 + depth / 6 + std::min(3, (bestScore - beta) / 200);
+            int R = 4 + depth / 6 + std::min(3, (bestScore - beta) / 100);
 
             m_position.MakeNullMove();
             EVAL nullScore = -abSearch(-beta, -beta + 1, depth - R, ply + 1, true, false);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-2";
+const std::string VERSION = "3.0-dev-3";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10168/

```
ELO   | 6.73 +- 4.65 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8832 W: 1905 L: 1734 D: 5193
```

http://chess.grantnet.us/test/10169/

```
ELO   | 2.96 +- 2.34 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 5.00]
Games | N: 23148 W: 3259 L: 3062 D: 16827
```