### PR TITLE
3.0-dev-4: probcut tunning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -301,7 +301,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         //  probcut
         //
 
-        if (depth >= 5 && abs(beta) < (CHECKMATE_SCORE + 50)) {
+        if (depth >= 5) {
             auto betaCut = beta + 100;
             MoveList captureMoves;
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-3";
+const std::string VERSION = "3.0-dev-4";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10175/

```
ELO   | 2.86 +- 2.27 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 37600 W: 8018 L: 7709 D: 21873
```

http://chess.grantnet.us/test/10176/

```
ELO   | 0.76 +- 1.14 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | -2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 97510 W: 13514 L: 13300 D: 70696
```