### PR TITLE
3.0-dev-5: quiets prunning tweaks

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -370,6 +370,12 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
                 History::fetchHistory(this, mv, ply, history);
 
+                if (depth <= m_cmpDepth[improving] && history.cmhistory < m_cmpHistoryLimit[improving])
+                    continue;
+
+                if (depth <= m_fmpDepth[improving] && history.fmhistory < m_fmpHistoryLimit[improving])
+                    continue;
+
                 auto futilityMargin = staticEval + 90 * depth;
 
                 if (futilityMargin <= alpha
@@ -379,12 +385,6 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
                 if (depth <= m_lmpDepth && quietsTried >= m_lmpPruningTable[improving][depth])
                     skipQuiets = true;
-
-                if (depth <= m_cmpDepth[improving] && history.cmhistory < m_cmpHistoryLimit[improving])
-                    continue;
-
-                if (depth <= m_fmpDepth[improving] && history.fmhistory < m_fmpHistoryLimit[improving])
-                    continue;
             }
 
             if (depth <= 8 && !inCheck) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-4";
+const std::string VERSION = "3.0-dev-5";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10183/

ELO   | 7.72 +- 5.10 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7384 W: 1613 L: 1449 D: 4322

http://chess.grantnet.us/test/10184/

ELO   | 2.62 +- 2.10 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 28876 W: 4083 L: 3865 D: 20928