### PR TITLE
3.0-dev-6: fix bogus condition for history calculation

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -30,7 +30,7 @@
 {
     assert(ply < MAX_PLY);
 
-    if (ply <= 2 || quetMoves.empty())
+    if (ply < 2 || quetMoves.empty())
         return;
 
     auto counterMove = pSearch->m_moveStack[ply - 1];

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-5";
+const std::string VERSION = "3.0-dev-6";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10199/

ELO   | 2.70 +- 2.12 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 42016 W: 8774 L: 8447 D: 24795

http://chess.grantnet.us/test/10201/

ELO   | 0.54 +- 1.40 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | -2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 64352 W: 8857 L: 8757 D: 46738