### PR TITLE
3.0-dev-7: depth 5 for null move pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -287,7 +287,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         //
 
         if (!isNull && depth >= 2 && m_position.NonPawnMaterial() && bestScore >= beta) {
-            int R = 4 + depth / 6 + std::min(3, (bestScore - beta) / 100);
+            int R = 5 + depth / 6 + std::min(3, (bestScore - beta) / 100);
 
             m_position.MakeNullMove();
             EVAL nullScore = -abSearch(-beta, -beta + 1, depth - R, ply + 1, true, false);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-6";
+const std::string VERSION = "3.0-dev-7";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10327/

ELO   | 5.49 +- 4.04 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11968 W: 2627 L: 2438 D: 6903

http://chess.grantnet.us/test/10335/

ELO   | 6.08 +- 3.83 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8572 W: 1241 L: 1091 D: 6240