### PR TITLE
3.0-dev-8: do not extend captures

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -435,7 +435,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             //   extensions
             //
 
-            newDepth += extensionRequired(mv, lastMove, m_position.InCheck(), ply, onPV, quietMoves.size(), history.cmhistory, history.fmhistory);
+            newDepth += extensionRequired(mv, lastMove, m_position.InCheck(), quietMoves.size(), history.cmhistory, history.fmhistory);
 
             EVAL e;
             if (legalMoves == 1)
@@ -666,17 +666,12 @@ void Search::clearStacks()
     }
 }
 
-int Search::extensionRequired(Move mv, Move lastMove, bool inCheck, int ply, bool onPV, size_t quietMoves, int cmhistory, int fmhistory)
+int Search::extensionRequired(Move mv, Move lastMove, bool inCheck, size_t quietMoves, int cmhistory, int fmhistory)
 {
     if (quietMoves <= 4 && cmhistory >= 10000 && fmhistory >= 10000)
         return 1;
     else if (inCheck)
         return 1;
-    else if (ply < 2 * m_depth)
-    {
-        if (onPV && lastMove && mv.To() == lastMove.To() && lastMove.Captured())
-            return 1;
-    }
     return 0;
 }
 

--- a/src/search.h
+++ b/src/search.h
@@ -91,7 +91,7 @@ private:
 #endif
     EVAL abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bool rootNode, Move skipMove = 0);
     EVAL qSearch(EVAL alpha, EVAL beta, int ply, int depth, bool isNull = false);
-    int extensionRequired(Move mv, Move lastMove, bool inCheck, int ply, bool onPV, size_t quietMoves, int cmhistory, int fmhistory);
+    inline int extensionRequired(Move mv, Move lastMove, bool inCheck, size_t quietMoves, int cmhistory, int fmhistory);
     bool ProbeHash(TEntry & hentry);
     bool isGameOver(Position & pos, std::string & result, std::string & comment, Move & bestMove, int & legalMoves);
     void printPV(const Position& pos, int iter, int selDepth, EVAL score, const Move* pv, int pvSize, Move mv, uint64_t sumNodes, uint64_t sumHits, uint64_t nps);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-7";
+const std::string VERSION = "3.0-dev-8";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10536/

ELO   | 5.25 +- 3.53 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10192 W: 1475 L: 1321 D: 7396

http://chess.grantnet.us/test/10533/

ELO   | 2.91 +- 2.31 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 36008 W: 7653 L: 7351 D: 21004