### PR TITLE
3.0-dev-9: prevent search explosion due to history extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -435,7 +435,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             //   extensions
             //
 
-            newDepth += extensionRequired(mv, lastMove, m_position.InCheck(), quietMoves.size(), history.cmhistory, history.fmhistory);
+            newDepth += extensionRequired(mv, lastMove, m_position.InCheck(), quietMove, onPV, history.cmhistory, history.fmhistory);
 
             EVAL e;
             if (legalMoves == 1)
@@ -666,9 +666,9 @@ void Search::clearStacks()
     }
 }
 
-int Search::extensionRequired(Move mv, Move lastMove, bool inCheck, size_t quietMoves, int cmhistory, int fmhistory)
+int Search::extensionRequired(Move mv, Move lastMove, bool inCheck, bool quietMove, bool onPV, int cmhistory, int fmhistory)
 {
-    if (quietMoves <= 4 && cmhistory >= 10000 && fmhistory >= 10000)
+    if (onPV && quietMove && cmhistory >= 10000 && fmhistory >= 10000)
         return 1;
     else if (inCheck)
         return 1;

--- a/src/search.h
+++ b/src/search.h
@@ -91,7 +91,7 @@ private:
 #endif
     EVAL abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bool rootNode, Move skipMove = 0);
     EVAL qSearch(EVAL alpha, EVAL beta, int ply, int depth, bool isNull = false);
-    inline int extensionRequired(Move mv, Move lastMove, bool inCheck, size_t quietMoves, int cmhistory, int fmhistory);
+    inline int extensionRequired(Move mv, Move lastMove, bool inCheck, bool quietMove, bool onPV, int cmhistory, int fmhistory);
     bool ProbeHash(TEntry & hentry);
     bool isGameOver(Position & pos, std::string & result, std::string & comment, Move & bestMove, int & legalMoves);
     void printPV(const Position& pos, int iter, int selDepth, EVAL score, const Move* pv, int pvSize, Move mv, uint64_t sumNodes, uint64_t sumHits, uint64_t nps);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-8";
+const std::string VERSION = "3.0-dev-9";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10541/

ELO   | 1.63 +- 2.25 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.00 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 25008 W: 3475 L: 3358 D: 18175

http://chess.grantnet.us/test/10540/

ELO   | 1.01 +- 2.37 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 34336 W: 7230 L: 7130 D: 19976