### PR TITLE
3.0-dev-10: use smaller soft limit for sd tc

### DIFF
--- a/src/time.cpp
+++ b/src/time.cpp
@@ -162,7 +162,7 @@ bool Time::evaluate()
 
     auto bonus  = m_increment ? getEnemyLowTimeBonus() : 0;
     m_hardLimit = (m_remainingTime / 12) + (m_increment / 2) + bonus;
-    m_softLimit = m_hardLimit / 4;
+    m_softLimit = m_increment ? (m_hardLimit / 4) : (m_hardLimit / 5);
 
     return true;
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-9";
+const std::string VERSION = "3.0-dev-10";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10547/

ELO   | 10.30 +- 5.46 (95%)
SPRT  | 60.0+0.0s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4656 W: 767 L: 629 D: 3260

http://chess.grantnet.us/test/10546/

ELO   | 16.13 +- 8.16 (95%)
SPRT  | 10.0+0.0s Threads=1 Hash=8MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3385 W: 902 L: 745 D: 1738

regression run on tc with increments

http://chess.grantnet.us/test/10548/

ELO   | 0.19 +- 1.69 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 67072 W: 13930 L: 13894 D: 39248

http://chess.grantnet.us/test/10551/

ELO   | 0.08 +- 1.16 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.05 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 95568 W: 13201 L: 13178 D: 69189