### PR TITLE
3.0-dev-11: count non played quiets for lmp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -420,13 +420,13 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
         auto lastMove = m_position.LastMove();
 
+        if (quietMove) {
+            ++quietsTried;
+            quietMoves.emplace_back(mv);
+        }
+
         if (m_position.MakeMove(mv)) {
             ++legalMoves;
-
-            if (quietMove) {
-                ++quietsTried;
-                quietMoves.emplace_back(mv);
-            }
 
             m_moveStack[ply]  = mv;
             m_pieceStack[ply] = mv.Piece();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-10";
+const std::string VERSION = "3.0-dev-11";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10588/

ELO   | 9.05 +- 4.86 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5416 W: 820 L: 679 D: 3917

http://chess.grantnet.us/test/10587/

ELO   | 7.21 +- 4.81 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7904 W: 1646 L: 1482 D: 4776