### PR TITLE
3.0-dev-12: remove dummy 100 multiplier for history ordering

### DIFF
--- a/src/moveeval.cpp
+++ b/src/moveeval.cpp
@@ -78,7 +78,7 @@ const EVAL SORT_VALUE[14] = { 0, 0, VAL_P, VAL_P, VAL_N, VAL_N, VAL_B, VAL_B, VA
         else if (mv == pSearch->m_killerMoves[ply][0] || mv == pSearch->m_killerMoves[ply][1])
             mvlist[j].m_score = s_SortKiller;
         else {
-            mvlist[j].m_score = 100 * pSearch->m_history[pSearch->m_position.Side()][mv.From()][mv.To()];
+            mvlist[j].m_score = pSearch->m_history[pSearch->m_position.Side()][mv.From()][mv.To()];
 
             if (counterMove)
                 mvlist[j].m_score += pSearch->m_followTable[0][counterPiece][counterTo][mv.Piece()][mv.To()];

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-11";
+const std::string VERSION = "3.0-dev-12";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10695/

ELO   | 7.40 +- 4.39 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6715 W: 1010 L: 867 D: 4838

http://chess.grantnet.us/test/10694/

ELO   | 9.89 +- 5.98 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5625 W: 1301 L: 1141 D: 3183