### PR TITLE
3.0-dev-13: fix crash when 'ucinewgame' command is not issued

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-12";
+const std::string VERSION = "3.0-dev-13";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)
@@ -67,6 +67,9 @@ int Uci::handleCommands()
         std::cout << "Fatal error: unable to allocate memory for transposition table" << std::endl;
         return 1;
     }
+
+    // humanoids often forget to issue a 'ucinewgame' command, so let's rectify this:
+    onUciNewGame();
 
     while (true) {
         std::string cmd;
@@ -297,6 +300,7 @@ void Uci::onSetOption(commandParams params)
         if (threads > MAX_THREADS || threads < MIN_THREADS)
             std::cout << "Unable set threads value. Make sure number is correct" << std::endl;
         m_searcher.setThreadCount(threads - 1);
+        onUciNewGame(); // reset internal state of each thread
     }
     else if (name == "Skill Level") {
         auto level = atoi(value.c_str());


### PR DESCRIPTION
Fixes #218

http://chess.grantnet.us/test/10697/

ELO   | 0.41 +- 1.82 (95%)
SPRT  | 10.0+0.0s Threads=4 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 53461 W: 10279 L: 10216 D: 32966

http://chess.grantnet.us/test/10696/

ELO   | 2.16 +- 3.23 (95%)
SPRT  | 10.0+0.0s Threads=1 Hash=8MB
LLR   | 3.03 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 20704 W: 4912 L: 4783 D: 11009