### PR TITLE
3.0-dev-14: fix crash when thread position is not initialized

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -631,6 +631,14 @@ EVAL Search::qSearch(EVAL alpha, EVAL beta, int ply, int depth, bool isNull/* = 
     return bestScore;
 }
 
+void Search::setInitial()
+{
+    m_position.SetInitial();
+
+    for (unsigned int i = 0; i < m_thc; ++i)
+        m_threadParams[i].m_position.SetInitial();
+}
+
 void Search::clearHistory()
 {
     memset(m_history, 0, sizeof(m_history));

--- a/src/search.h
+++ b/src/search.h
@@ -65,6 +65,7 @@ public:
 
 public:
     uint64_t startSearch(Time time, int depth, bool ponder, bool bench = false);
+    void setInitial();
     void clearHistory();
     void clearKillers();
     void clearStacks();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-13";
+const std::string VERSION = "3.0-dev-14";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)
@@ -141,7 +141,7 @@ void Uci::onUci()
 
 void Uci::onUciNewGame()
 {
-    m_searcher.m_position.SetInitial();
+    m_searcher.setInitial();
 
     TTable::instance().clearHash(m_searcher.getThreadsCount());
     TTable::instance().clearAge();


### PR DESCRIPTION
http://chess.grantnet.us/test/10725/

ELO   | 1.09 +- 2.39 (95%)
SPRT  | 5.0+0.05s Threads=4 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 32098 W: 6388 L: 6287 D: 19423

http://chess.grantnet.us/test/10720/

ELO   | -0.21 +- 1.23 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 126424 W: 25975 L: 26051 D: 74398