### PR TITLE
3.0-dev-16: remove unused counter move table

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -67,9 +67,6 @@
             pSearch->m_followTable[1][followPiece][followTo][piece][to] = entry;
         }
     }
-
-    if (counterMove)
-        pSearch->m_counterTable[!colour][counterPiece][counterTo] = best;
 }
 
 /*static */void History::setKillerMove(Search * pSearch, Move mv, int ply)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -662,7 +662,6 @@ void Search::clearStacks()
 
     memset(m_pieceStack, 0, sizeof(m_pieceStack));
     memset(m_followTable, 0, sizeof(m_followTable));
-    memset(m_counterTable, 0, sizeof(m_counterTable));
     memset(m_evalStack, 0, sizeof(m_evalStack));
     memset(m_pvSize, 0, sizeof(m_pvSize));
 
@@ -673,7 +672,6 @@ void Search::clearStacks()
 
         memset(m_threadParams[i].m_pieceStack, 0, sizeof(m_pieceStack));
         memset(m_threadParams[i].m_followTable, 0, sizeof(m_followTable));
-        memset(m_threadParams[i].m_counterTable, 0, sizeof(m_counterTable));
         memset(m_threadParams[i].m_evalStack, 0, sizeof(m_evalStack));
         memset(m_threadParams[i].m_pvSize, 0, sizeof(m_threadParams[i].m_pvSize));
     }

--- a/src/search.h
+++ b/src/search.h
@@ -122,7 +122,6 @@ private:
     PIECE m_pieceStack[MAX_PLY + 4];
     EVAL m_evalStack[MAX_PLY + 4];
     int m_followTable[2][14][64][14][64];
-    Move m_counterTable[2][14][64];
     int m_logLMRTable[64][64];
     Time m_time, m_ponderTime;
     std::unique_ptr<std::thread> m_principalThread;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-15";
+const std::string VERSION = "3.0-dev-16";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10743/

ELO   | -0.06 +- 0.84 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 1.43 (-2.94, 2.94) [-1.25, 0.25]
Games | N: 269272 W: 55663 L: 55708 D: 157901