### PR TITLE
3.0-dev-17: fix out of boundary access for history array

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -95,15 +95,13 @@
 
     if (counterMove)
         hh.cmhistory = pSearch->m_followTable[0][counterPiece][counterTo][piece][to];
-    else
-        counterMove = 0;
 
-    auto followMove = pSearch->m_moveStack[ply - 2];
-    auto followPiece = pSearch->m_pieceStack[ply - 2];
-    auto followTo = followMove.To();
+    if (ply > 1) {
+        auto followMove = pSearch->m_moveStack[ply - 2];
+        auto followPiece = pSearch->m_pieceStack[ply - 2];
+        auto followTo = followMove.To();
 
-    if (followMove)
-        hh.fmhistory = pSearch->m_followTable[1][followPiece][followTo][mv.Piece()][to];
-    else
-        hh.fmhistory = 0;
+        if (followMove)
+            hh.fmhistory = pSearch->m_followTable[1][followPiece][followTo][mv.Piece()][to];
+    }
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-16";
+const std::string VERSION = "3.0-dev-17";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10794/

ELO   | -0.27 +- 1.74 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 63040 W: 13031 L: 13080 D: 36929