### PR TITLE
Release Igel 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,31 +46,17 @@ The IGN networks comply with the following mandatory requirements:
 
 **Technical details**
 
-###### IGN-0
-
-Architecture: halfkp_256x2-32-32
-
-Training mode: two iterations
-
-Training data:
-
-Iteration 1:
-
-Search/Eval data: 2.3 billion of depth 8 search/eval data from Igel 2.6.0 (HCE)
-
-Validation data: 1 million of depth 10 search/eval data from Igel 2.6.0 (HCE)
-
-Iteration 2:
-
-Search/Eval data: 500 millions of depth 12 search/eval data from Igel 2.6.0 (HCE)
-
-Validation data: 1 million of depth 14 search/eval data from Igel 2.6.0 (HCE)
+| Generation    | Architecture       | Source of data         | Quantity          | Type            | Best network   |
+| ------------- | ------------------ | ---------------------- | ----------------- |  -------------- | -------------- |
+| ign-0         | halfkp_256x2-32-32 | Igel 2.6.0             | 2.3b d8, 500m d12 | HCE             | ign-0-9b1937cc |
+| ign-1         | halfkp_256x2-32-32 | Igel 2.6.0, Igel 2.9.0 | 9.5b d8, 1b d12   | HCE, NNUE       | ign-1-139b702b |
 
 ### Acknowledgements
 
 I would like to thank the authors and the community involved in the creation of the open source projects listed below. Their work influences development of Igel, and without them, this project wouldn't exist. Special thanks to Andrew Grant and Bojun Guo for supporting Igel development on OpenBench.
 
 * [OpenBench](https://github.com/AndyGrant/OpenBench/)
+* [nnue-pytorch](https://github.com/glinscott/nnue-pytorch)
 * [GreKo](http://greko.su/)
 * [Chess Programming Wiki](https://www.chessprogramming.org/)
 * [Ethereal](https://github.com/AndyGrant/Ethereal/)
@@ -101,7 +87,7 @@ On Linux:
 git clone https://github.com/vshcherbyna/igel.git ./igel
 cd igel
 git submodule update --init --recursive
-wget https://github.com/vshcherbyna/igel/releases/download/2.9.0/ign-0-9b1937cc -O ./network_file
+wget https://github.com/vshcherbyna/igel/releases/download/3.0.0/ign-1-139b702b -O ./network_file
 cmake -DEVALFILE=network_file -DEVAL_NNUE=1 -DUSE_PEXT=1 -DUSE_AVX2=1 -D_BTYPE=1 -DSYZYGY_SUPPORT=TRUE .
 make -j
 ```

--- a/history.txt
+++ b/history.txt
@@ -1,7 +1,31 @@
 Igel chess engine
 
 (c) 2002-2018 Vladimir Medvedev <vrm@bk.ru>
-(c) 2018-2020 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+(c) 2018-2021 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+
+Igel 3.0.0
+-------------
+04-Apr-2021
+
+- Train a new network using Igel 2.6.0 (HCE) and Igel 2.9.0 (NNUE) data: ign-1-139b702b
+- Fix in check extensions
+- Use incbin on Linux to inject network file into the binary
+- Tune null move prunning conditions
+- Tune probcut prunning conditions
+- Tune quiets prunning
+- Fix bogus condition for history calculation
+- Implement more aggressive null move prunning
+- Stop extension of captures
+- Prevent explosion of history extensions
+- Implement better time management for sudden death time control
+- Count not played quiets for LMP prunning
+- Remove dummy 100 multiplier for history ordering calculation
+- Fix compilation issues with gcc 10 and Android NDK's Clang
+- Remove unused counter move table
+- Fix out of boundary access for history array
+- Fix issue with singular extensions - reported by ChizhovVadim (author of CounterGo chess engine)
+- Fix crash when 'ucinewgame' command is not issued - reported by Jean-Paul (Ipmanchess)
+- Fix crash when thread position is not initialized - reported by Jean-Paul (Ipmanchess)
 
 Igel 2.9.0
 -------------

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,7 +57,7 @@ int main(int argc, const char* argv[])
     //  for debugging purposes load official network file ign-0-9b1937cc
     //
 
-    if (!Eval::NNUE::load_eval_file("ign-0-9b1937cc")) {
+    if (!Eval::NNUE::load_eval_file("ign-1-139b702b")) {
         std::cout << "Unable to set EvalFile. Aborting" << std::endl;
         abort();
     }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0-dev-17";
+const std::string VERSION = "3.0.0"; // "3.0-dev-17";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
Igel 3.0.0
-------------
04-Apr-2021

- Train a new network using Igel 2.6.0 (HCE) and Igel 2.9.0 (NNUE) data: ign-1-139b702b
- Fix in check extensions
- Use incbin on Linux to inject network file into the binary
- Tune null move prunning conditions
- Tune probcut prunning conditions
- Tune quiets prunning
- Fix bogus condition for history calculation
- Implement more aggressive null move prunning
- Stop extension of captures
- Prevent explosion of history extensions
- Implement better time management for sudden death time control
- Count not played quiets for LMP prunning
- Remove dummy 100 multiplier for history ordering calculation
- Fix compilation issues with gcc 10 and Android NDK's Clang
- Remove unused counter move table
- Fix out of boundary access for history array
- Fix issue with singular extensions - reported by ChizhovVadim (author of CounterGo chess engine)
- Fix crash when 'ucinewgame' command is not issued - reported by Jean-Paul (Ipmanchess)
- Fix crash when thread position is not initialized - reported by Jean-Paul (Ipmanchess)