### PR TITLE
3.1-dev-0: better time management for sd

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ I would like to thank the authors and the community involved in the creation of 
 
 ### Compiling
 
-Official compilation method involves CMake and Visual Studio 2019 and assumes a modern CPU with AVX2 support (most of the computers produced in last 8 years).
+Official compilation method involves cmake and gcc/Visual Studio 2019 and assumes a modern CPU with AVX2 support (most of the computers produced in last 8 years).
 
-On Windows:
+Using cmake/Visual Studio:
 
 ```
 git clone https://github.com/vshcherbyna/igel.git ./igel
@@ -81,7 +81,7 @@ git submodule update --init --recursive
 cmake -DEVAL_NNUE=1 -DUSE_AVX2=1 -D_BTYPE=1 -DSYZYGY_SUPPORT=TRUE -G "Visual Studio 16 2019" -A x64 .
 ```
 
-On Linux:
+Using cmake/gcc:
 
 ```
 git clone https://github.com/vshcherbyna/igel.git ./igel
@@ -92,10 +92,10 @@ cmake -DEVALFILE=network_file -DEVAL_NNUE=1 -DUSE_PEXT=1 -DUSE_AVX2=1 -D_BTYPE=1
 make -j
 ```
 
-It is also possible to compile using gcc and traditional makefile, consult ./src/makefile for more details.
+It is also possible to compile using gcc and a traditional makefile, please consult ./src/makefile for more details.
 
 ### Donation
 
 Consider supporting Igel development on [Patreon](https://www.patreon.com/igel).
 
-Igel is a hobby project, but it takes time and money to develop chess engine and train networks. A typical data generation session takes around 1 month of time for 3 billion depth 12 data set and I am currently renting expensive dedicated AMD EPYC hardware to make this happen.
+Igel is a hobby project, but it takes time and money to develop chess engine and train networks. Data generation session takes around 1 month of time for 3 billion depth 12 data set and I am currently renting expensive dedicated servers to help with that.

--- a/src/makefile
+++ b/src/makefile
@@ -9,7 +9,7 @@ SRC = *.cpp nnue/*.cpp nnue/features/*.cpp fathom/tbprobe.c
 
 GCCDEFINES = $(shell echo | $(CC) -m64 -march=native -E -dM -)
 
-EVALFILE = weights/ign-0-9b1937cc
+EVALFILE = weights/ign-1-139b702b
 NNFLAGS  = -DEVALFILE=\"$(EVALFILE)\"
 
 LIBS   = -std=c++17 -mpopcnt -pthread

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -162,7 +162,7 @@ bool Time::evaluate()
 
     auto bonus  = m_increment ? getEnemyLowTimeBonus() : 0;
     m_hardLimit = (m_remainingTime / 12) + (m_increment / 2) + bonus;
-    m_softLimit = m_increment ? (m_hardLimit / 4) : (m_hardLimit / 5);
+    m_softLimit = m_increment ? (m_hardLimit / 4) : (m_hardLimit / 6);
 
     return true;
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0.0"; // "3.0-dev-17";
+const std::string VERSION = "3.1-dev-0";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10897/

ELO   | 5.46 +- 3.60 (95%)
SPRT  | 60.0+0.0s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9744 W: 1407 L: 1254 D: 7083

http://chess.grantnet.us/test/10896/

ELO   | 3.64 +- 2.93 (95%)
SPRT  | 10.0+0.0s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 23848 W: 5387 L: 5137 D: 13324