### PR TITLE
3.1-dev-1: no tt cutoff for null moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -166,7 +166,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
     TEntry hEntry{};
     EVAL ttScore;
     auto onPV  = (beta - alpha > 1);
-    auto ttHit = !skipMove && ProbeHash(hEntry);
+    auto ttHit = !skipMove && !isNull && ProbeHash(hEntry);
 
     if (ttHit) {
         ttScore = hEntry.m_data.score;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.1-dev-0";
+const std::string VERSION = "3.1-dev-1";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10938/

ELO   | 11.70 +- 5.45 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3952 W: 569 L: 436 D: 2947

http://chess.grantnet.us/test/10936/

ELO   | 11.99 +- 6.45 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4320 W: 913 L: 764 D: 2643