### PR TITLE
3.1-dev-2: skip null move pruning in tt hit

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -164,9 +164,10 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
     Move hashMove{};
     TEntry hEntry{};
-    EVAL ttScore;
-    auto onPV  = (beta - alpha > 1);
-    auto ttHit = !skipMove && !isNull && ProbeHash(hEntry);
+
+    EVAL ttScore = 0;
+    auto onPV    = (beta - alpha > 1);
+    auto ttHit   = !skipMove && !isNull && ProbeHash(hEntry);
 
     if (ttHit) {
         ttScore = hEntry.m_data.score;
@@ -286,7 +287,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         //   null move
         //
 
-        if (!isNull && depth >= 2 && m_position.NonPawnMaterial() && bestScore >= beta) {
+        if (!isNull && depth >= 2 && bestScore >= beta && (!ttHit || !(hEntry.m_data.type == HASH_BETA) || ttScore >= beta) && m_position.NonPawnMaterial()) {
             int R = 5 + depth / 6 + std::min(3, (bestScore - beta) / 100);
 
             m_position.MakeNullMove();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.1-dev-1";
+const std::string VERSION = "3.1-dev-2";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10954/

ELO   | 5.56 +- 3.49 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9060 W: 1152 L: 1007 D: 6901

http://chess.grantnet.us/test/10952/

ELO   | 3.85 +- 3.04 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 19040 W: 3732 L: 3521 D: 11787