### PR TITLE
3.0.3: remove unused lastmove variable

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -419,8 +419,6 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
                 return betaCut;
         }
 
-        auto lastMove = m_position.LastMove();
-
         if (quietMove) {
             ++quietsTried;
             quietMoves.emplace_back(mv);
@@ -436,7 +434,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             //   extensions
             //
 
-            newDepth += extensionRequired(mv, lastMove, m_position.InCheck(), quietMove, onPV, history.cmhistory, history.fmhistory);
+            newDepth += extensionRequired(mv, m_position.InCheck(), quietMove, onPV, history.cmhistory, history.fmhistory);
 
             EVAL e;
             if (legalMoves == 1)
@@ -678,7 +676,7 @@ void Search::clearStacks()
     }
 }
 
-int Search::extensionRequired(Move mv, Move lastMove, bool inCheck, bool quietMove, bool onPV, int cmhistory, int fmhistory)
+int Search::extensionRequired(Move mv, bool inCheck, bool quietMove, bool onPV, int cmhistory, int fmhistory)
 {
     if (onPV && quietMove && cmhistory >= 10000 && fmhistory >= 10000)
         return 1;

--- a/src/search.h
+++ b/src/search.h
@@ -92,7 +92,7 @@ private:
 #endif
     EVAL abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bool rootNode, Move skipMove = 0);
     EVAL qSearch(EVAL alpha, EVAL beta, int ply, int depth, bool isNull = false);
-    inline int extensionRequired(Move mv, Move lastMove, bool inCheck, bool quietMove, bool onPV, int cmhistory, int fmhistory);
+    inline int extensionRequired(Move mv, bool inCheck, bool quietMove, bool onPV, int cmhistory, int fmhistory);
     bool ProbeHash(TEntry & hentry);
     bool isGameOver(Position & pos, std::string & result, std::string & comment, Move & bestMove, int & legalMoves);
     void printPV(const Position& pos, int iter, int selDepth, EVAL score, const Move* pv, int pvSize, Move mv, uint64_t sumNodes, uint64_t sumHits, uint64_t nps);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.1-dev-2";
+const std::string VERSION = "3.0.3";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/10965/

ELO   | 0.65 +- 2.02 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 43420 W: 8357 L: 8276 D: 26787