### PR TITLE
3.0.5: new time hardlimit: 13

### DIFF
--- a/src/time.cpp
+++ b/src/time.cpp
@@ -161,7 +161,7 @@ bool Time::evaluate()
     //
 
     auto bonus  = m_increment ? getEnemyLowTimeBonus() : 0;
-    m_hardLimit = (m_remainingTime / 12) + (m_increment / 2) + bonus;
+    m_hardLimit = (m_remainingTime / 13) + (m_increment / 2) + bonus;
     m_softLimit = m_increment ? (m_hardLimit / 4) : (m_hardLimit / 6);
 
     return true;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0.4";
+const std::string VERSION = "3.0.5";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/11041/

ELO   | -0.05 +- 1.00 (95%)
SPRT  | 60.0+0.0s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 123804 W: 16560 L: 16577 D: 90667

http://chess.grantnet.us/test/11036/

ELO   | 0.35 +- 1.32 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 65216 W: 8103 L: 8037 D: 49076

http://chess.grantnet.us/test/11031/

ELO   | 1.90 +- 2.81 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 22144 W: 4260 L: 4139 D: 13745