### PR TITLE
Release Igel 3.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ The IGN networks comply with the following mandatory requirements:
 
 **Technical details**
 
-| Generation    | Architecture       | Source of data         | Quantity          | Type            | Best network   |
-| ------------- | ------------------ | ---------------------- | ----------------- |  -------------- | -------------- |
-| ign-0         | halfkp_256x2-32-32 | Igel 2.6.0             | 2.3b d8, 500m d12 | HCE             | ign-0-9b1937cc |
-| ign-1         | halfkp_256x2-32-32 | Igel 2.6.0, Igel 2.9.0 | 9.5b d8, 1b d12   | HCE, NNUE       | ign-1-139b702b |
+| Generation    | Architecture       | Source of data                     | Quantity          | Type            | Best network   |
+| ------------- | ------------------ | ---------------------------------- | ----------------- |  -------------- | -------------- |
+| ign-0         | halfkp_256x2-32-32 | Igel 2.6.0                         | 2.3b d8, 500m d12 | HCE             | ign-0-9b1937cc |
+| ign-1         | halfkp_256x2-32-32 | Igel 2.6.0, Igel 2.9.0, Igel 3.0.0 | 12b d8, 1b d12    | HCE, NNUE       | ign-1-d593efbd |
 
 ### Acknowledgements
 
@@ -87,7 +87,7 @@ Using cmake/gcc:
 git clone https://github.com/vshcherbyna/igel.git ./igel
 cd igel
 git submodule update --init --recursive
-wget https://github.com/vshcherbyna/igel/releases/download/3.0.0/ign-1-139b702b -O ./network_file
+wget https://github.com/vshcherbyna/igel/releases/download/3.0.5/ign-1-d593efbd -O ./network_file
 cmake -DEVALFILE=network_file -DEVAL_NNUE=1 -DUSE_PEXT=1 -DUSE_AVX2=1 -D_BTYPE=1 -DSYZYGY_SUPPORT=TRUE .
 make -j
 ```
@@ -98,4 +98,4 @@ It is also possible to compile using gcc and a traditional makefile, please cons
 
 Consider supporting Igel development on [Patreon](https://www.patreon.com/igel).
 
-Igel is a hobby project, but it takes time and money to develop chess engine and train networks. Data generation session takes around 1 month of time for 3 billion depth 12 data set and I am currently renting expensive dedicated servers to help with that.
+Igel is a hobby project, but it takes time and money to develop chess engine and train networks. Currently I am renting dedicated server hardware at OVH and I appreciate any help/donation to help pay the server bills.

--- a/history.txt
+++ b/history.txt
@@ -1,7 +1,18 @@
-Igel chess engine
+Igel - open source chess engine forked from GreKo 2018.01.
 
-(c) 2002-2018 Vladimir Medvedev <vrm@bk.ru>
+(c) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
 (c) 2018-2021 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+
+Igel 3.0.5
+-------------
+28-Apr-2021
+
+- Train a new network using Igel 2.6.0 (HCE), Igel 2.9.0 (NNUE) and Igel 3.0.0 (NNUE) data: ign-1-d593efbd
+- Better time management in sd time control
+- Skip tt cutoff for null moves in search
+- Skip null move prunning on tt hit
+- Vote for best thread in SMP mode
+- Less aggressive time use in non repeated tc
 
 Igel 3.0.0
 -------------
@@ -24,8 +35,8 @@ Igel 3.0.0
 - Remove unused counter move table
 - Fix out of boundary access for history array
 - Fix issue with singular extensions - reported by ChizhovVadim (author of CounterGo chess engine)
-- Fix crash when 'ucinewgame' command is not issued - reported by Jean-Paul (Ipmanchess)
-- Fix crash when thread position is not initialized - reported by Jean-Paul (Ipmanchess)
+- Fix crash when 'ucinewgame' command is not issued - reported by Ipmanchess
+- Fix crash when thread position is not initialized - reported by Ipmanchess
 
 Igel 2.9.0
 -------------

--- a/src/makefile
+++ b/src/makefile
@@ -9,7 +9,7 @@ SRC = *.cpp nnue/*.cpp nnue/features/*.cpp fathom/tbprobe.c
 
 GCCDEFINES = $(shell echo | $(CC) -m64 -march=native -E -dM -)
 
-EVALFILE = weights/ign-1-139b702b
+EVALFILE = weights/ign-1-d593efbd
 NNFLAGS  = -DEVALFILE=\"$(EVALFILE)\"
 
 LIBS   = -std=c++17 -mpopcnt -pthread


### PR DESCRIPTION
Igel 3.0.5
-------------
28-Apr-2021

- Train a new network using Igel 2.6.0 (HCE), Igel 2.9.0 (NNUE) and Igel 3.0.0 (NNUE) data: ign-1-d593efbd
- Better time management in sd time control
- Skip tt cutoff for null moves in search
- Skip null move prunning on tt hit
- Vote for best thread in SMP mode
- Less aggressive time use in non repeated tc