### PR TITLE
3.0.7: more aggressive prunning of quiets when not improving

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -145,7 +145,7 @@ private:
     static constexpr int m_lmpDepth = 8;
     static constexpr int m_lmpPruningTable[2][9] =
     {
-        {  0,  3,  4,  6, 10, 14, 19, 25, 31 },
+        {  0,  2,  3,  5,  9, 13, 18, 24, 30 },
         {  0,  5,  7, 11, 17, 26, 36, 48, 63 },
     };
     static constexpr int m_cmpDepth[]        = { 3, 2           };

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0.6";
+const std::string VERSION = "3.0.7";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/12177/

ELO   | 1.16 +- 0.75 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 171440 W: 17932 L: 17361 D: 136147

http://chess.grantnet.us/test/12174/

ELO   | 2.36 +- 1.86 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 44176 W: 7485 L: 7185 D: 29506