### PR TITLE
3.0.9: avoid tt cutoff for rule50

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -179,7 +179,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         if (ttScore < -CHECKMATE_SCORE + 50 && ttScore >= -CHECKMATE_SCORE)
             ttScore += ply;
         if (hEntry.m_data.depth >= depth && (depth == 0 || !onPV)) {
-            if (!onPV && (hEntry.m_data.type == HASH_EXACT
+            if (!onPV && (m_position.Fifty() < 90) && (hEntry.m_data.type == HASH_EXACT
                 || (hEntry.m_data.type == HASH_BETA && ttScore >= beta)
                 || (hEntry.m_data.type == HASH_ALPHA && ttScore <= alpha)))
                 return ttScore;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.0.8";
+const std::string VERSION = "3.0.9";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/12578/

ELO   | 0.93 +- 1.59 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 38328 W: 4070 L: 3967 D: 30291

http://chess.grantnet.us/test/12567/

ELO   | 1.23 +- 2.26 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 30136 W: 5069 L: 4962 D: 20105