### PR TITLE
3.1.1: smaller margin for prunning quiets

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -395,8 +395,8 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
                 int seeMargin[2];
 
-                static const int SEEQuietMargin = -80;
-                static const int SEENoisyMargin = -18;
+                static const int SEEQuietMargin = -60;
+                static const int SEENoisyMargin = -10;
 
                 seeMargin[0] = SEENoisyMargin * depth * depth;
                 seeMargin[1] = SEEQuietMargin * depth;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.1.0";
+const std::string VERSION = "3.1.1";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/26300/

ELO   | 7.02 +- 4.52 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7720 W: 1396 L: 1240 D: 5084

http://chess.grantnet.us/test/26320/

ELO   | 2.12 +- 1.49 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 42232 W: 4420 L: 4162 D: 33650

BENCH : 5,306,337