### PR TITLE
3.1.2: scale down eval to 1000

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -151,7 +151,7 @@ EVAL Evaluator::evaluate(Position & pos)
     nnueEval = static_cast<EVAL>(Eval::NNUE::evaluate(pos));
     pawns    = pos.Count(PAWN | WHITE) + pos.Count(PAWN | BLACK);
     material = pos.nonPawnMaterial() + (pawns * VAL_P);
-    return nnueEval * (600 + material / 32) / 1280 + Tempo;
+    return nnueEval * (600 + material / 32) / 1000 + Tempo;
 #endif
 
     memset(m_pieceAttacks,         0, sizeof(m_pieceAttacks));

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.1.1";
+const std::string VERSION = "3.1.2";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/26462/

ELO   | 1.20 +- 0.95 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 101928 W: 10335 L: 9982 D: 81611

http://chess.grantnet.us/test/26460/

ELO   | 3.46 +- 2.62 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 22864 W: 3982 L: 3754 D: 15128