### PR TITLE
3.1.3: history extensions only on non pv moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -437,7 +437,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             //   extensions
             //
 
-            newDepth += extensionRequired(mv, m_position.InCheck(), quietMove, onPV, history.cmhistory, history.fmhistory);
+            newDepth += extensionRequired(m_position.InCheck(), onPV, history.cmhistory, history.fmhistory);
 
             EVAL e;
             if (legalMoves == 1)
@@ -679,9 +679,9 @@ void Search::clearStacks()
     }
 }
 
-int Search::extensionRequired(Move mv, bool inCheck, bool quietMove, bool onPV, int cmhistory, int fmhistory)
+int Search::extensionRequired(bool inCheck, bool onPV, int cmhistory, int fmhistory)
 {
-    if (onPV && quietMove && cmhistory >= 10000 && fmhistory >= 10000)
+    if (!onPV && cmhistory >= 10000 && fmhistory >= 10000)
         return 1;
     else if (inCheck)
         return 1;

--- a/src/search.h
+++ b/src/search.h
@@ -92,7 +92,7 @@ private:
 #endif
     EVAL abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bool rootNode, Move skipMove = 0);
     EVAL qSearch(EVAL alpha, EVAL beta, int ply, int depth, bool isNull = false);
-    inline int extensionRequired(Move mv, bool inCheck, bool quietMove, bool onPV, int cmhistory, int fmhistory);
+    inline int extensionRequired(bool inCheck, bool onPV, int cmhistory, int fmhistory);
     bool ProbeHash(TEntry & hentry);
     bool isGameOver(Position & pos, std::string & result, std::string & comment, Move & bestMove, int & legalMoves);
     void printPV(const Position& pos, int iter, int selDepth, EVAL score, const Move* pv, int pvSize, Move mv, uint64_t sumNodes, uint64_t sumHits, uint64_t nps);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.1.2";
+const std::string VERSION = "3.1.3";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/26599/

ELO   | -1.20 +- 1.99 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 63024 W: 16878 L: 17095 D: 29051

http://chess.grantnet.us/test/26602/

ELO   | 1.30 +- 3.93 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 14912 W: 3736 L: 3680 D: 7496

BENCH : 4,489,349