### PR TITLE
3.1.5: less reductions in lmp when not improving

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,4 @@ It is also possible to compile using gcc and a traditional makefile, please cons
 
 ### Donation
 
-Igel is a hobby project, but it takes time to develop chess engine and money to train Igel networks. I am in need of renting a dedicated server to train Igel networks and I appreciate any donation to help paying the server bills. **Due to these reasons, active development and training of Igel networks has stopped**.
-
-Consider supporting Igel development via [PayPal](https://www.paypal.com/donate/?hosted_button_id=37NPEAY9XLRJE). 
-
-As of now 0.00 USD were donated to support Igel.
+Thank you so much for supporting Igel's development and training via [PayPal](https://www.paypal.com/donate/?hosted_button_id=37NPEAY9XLRJE).

--- a/src/search.h
+++ b/src/search.h
@@ -145,7 +145,7 @@ private:
     static constexpr int m_lmpDepth = 8;
     static constexpr int m_lmpPruningTable[2][9] =
     {
-        {  0,  2,  3,  5,  9, 13, 18, 24, 30 },
+        {  0,  1,  2,  3,  5, 9, 13, 18,  25 },
         {  0,  5,  7, 11, 17, 26, 36, 48, 63 },
     };
     static constexpr int m_cmpDepth[]        = { 3, 2           };

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.1.4";
+const std::string VERSION = "3.1.5";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/29391/

ELO   | 2.56 +- 2.06 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 58344 W: 15773 L: 15343 D: 27228

http://chess.grantnet.us/test/29393/

ELO   | 2.64 +- 2.10 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 52536 W: 13412 L: 13013 D: 26111