### PR TITLE
3.1.6: negative extensions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -406,7 +406,8 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             }
         }
 
-        int newDepth = depth - 1;
+        int newDepth  = depth - 1;
+        int extension = 0;
 
         //
         //  singular extensions
@@ -417,9 +418,11 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             auto score = abSearch(betaCut - 1, betaCut, depth / 2, ply + 1, false, false, mv);
 
             if (score < betaCut)
-                ++newDepth;
+                extension = 1;
             else if (betaCut >= beta)
                 return betaCut;
+            else if (ttHit && ttScore >= beta)
+                extension = -2; // negative extension
         }
 
         if (quietMove) {
@@ -437,7 +440,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             //   extensions
             //
 
-            newDepth += extensionRequired(m_position.InCheck(), onPV, history.cmhistory, history.fmhistory);
+            newDepth += extensionRequired(m_position.InCheck(), onPV, history.cmhistory, history.fmhistory) + extension;
 
             EVAL e;
             if (legalMoves == 1)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.1.5";
+const std::string VERSION = "3.1.6";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/29439/

ELO   | 3.99 +- 2.93 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 28656 W: 7789 L: 7460 D: 13407

http://chess.grantnet.us/test/29442/

ELO   | 3.47 +- 2.62 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 33832 W: 8666 L: 8328 D: 16838

BENCH: 4444250