### PR TITLE
3.1.7: remove useless code in qs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -619,9 +619,6 @@ EVAL Search::qSearch(EVAL alpha, EVAL beta, int ply, int depth, bool isNull/* = 
                     alpha = e;
                     bestMove = mv;
                     type = HASH_EXACT;
-                    m_pv[ply][0] = mv;
-                    memcpy(m_pv[ply] + 1, m_pv[ply + 1], m_pvSize[ply + 1] * sizeof(Move));
-                    m_pvSize[ply] = 1 + m_pvSize[ply + 1];
                 }
             }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.1.6";
+const std::string VERSION = "3.1.7";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/29515/

ELO   | -0.39 +- 1.27 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 153408 W: 41042 L: 41212 D: 71154