### PR TITLE
3.1.8: futility pruning improvements

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -266,6 +266,8 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             bestScore = ttScore;
     }
 
+    auto improving = ply >= 2 && staticEval > m_evalStack[ply - 2];
+
     //
     //  apply prunning when we are not in check and not on PV
     //
@@ -283,7 +285,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         //  static null move pruning
         //
 
-        if (depth <= 8 && bestScore - 85 * depth > beta)
+        if (depth <= 8 && bestScore - 85 * (depth - improving) >= beta)
             return bestScore;
 
         //
@@ -351,7 +353,6 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
     auto mvSize = mvlist.Size();
 
     std::vector<Move> quietMoves;
-    auto improving = ply >= 2 && staticEval > m_evalStack[ply - 2];
     m_killerMoves[ply + 1][0] = m_killerMoves[ply + 1][1] = 0;
     auto quietsTried = 0;
     auto skipQuiets = false;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.1.7";
+const std::string VERSION = "3.1.8";
 
 #if defined(ENV64BIT)
     #if defined(_BTYPE)


### PR DESCRIPTION
http://chess.grantnet.us/test/29572/

ELO   | 8.87 +- 4.84 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 10656 W: 3012 L: 2740 D: 4904

http://chess.grantnet.us/test/29573/

ELO   | 4.63 +- 3.20 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 22448 W: 5711 L: 5412 D: 11325

BENCH: 3700833