### PR TITLE
3.5.1: scale nnue eval

### DIFF
--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -35,12 +35,12 @@ INCBIN(EmbeddedNNUE, EVALFILE);
 
 EVAL Evaluator::evaluate(Position & pos)
 {
-    EVAL scale = 1136 + 20 * pos.nonPawnMaterial() / 1024;
+    EVAL scale = 600 + 20 * pos.nonPawnMaterial() / 1024;
     EVAL v = static_cast<EVAL>(NnueEvaluate(pos) * scale / 1024);
 
     v = v * (208 - pos.Fifty()) / 208;
 
-    return v;
+    return v + Tempo;
 }
 
 void Evaluator::initEval()

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.5.0";
+const std::string VERSION = "3.5.1";
 const std::string ARCHITECTURE = " 64 "
 
 #if _BTYPE==0


### PR DESCRIPTION
http://chess.grantnet.us/test/32151/

ELO   | 5.81 +- 3.78 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 17656 W: 4965 L: 4670 D: 8021

http://chess.grantnet.us/test/32153/

ELO   | 14.20 +- 6.26 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 6144 W: 1722 L: 1471 D: 2951

bench: 17885511