### PR TITLE
3.5.2: remove instant moves handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ I would like to thank the authors and the community involved in the creation of 
 
 ### Compiling
 
-Official compilation method involves cmake and gcc/Visual Studio 2019 and assumes a modern CPU with AVX2 support (most of the computers produced in last 8 years).
+Official compilation method involves cmake and gcc/Visual Studio 2019 and assumes a modern CPU with AVX2 support (most of the computers produced in last 9 years).
 
 Using cmake/Visual Studio 2022:
 
@@ -63,7 +63,7 @@ git clone https://github.com/vshcherbyna/igel.git ./igel
 cd igel
 git submodule update --init --recursive
 wget https://github.com/vshcherbyna/igel/releases/download/3.5.0/c049c117 -O ./network_file
-cmake -DEVALFILE=network_file -DUSE_PEXT=1 -DUSE_AVX2=1 -D_BTYPE=1 -DSYZYGY_SUPPORT=TRUE .
+cmake -DEVALFILE=network_file -DUSE_AVX2=1 -D_BTYPE=1 -DSYZYGY_SUPPORT=TRUE .
 make -j
 ```
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1022,16 +1022,6 @@ uint64_t Search::startSearch(Time time, int depth, bool ponderSearch, bool bench
             return 0;
         }
 
-        //
-        //  Check if only a single legal move possible at this position
-        //
-
-        if (legalMoves == 1 && time.chopperMove()) {
-            waitUntilCompletion();
-            printBestMove(this, m_position, onlyMove, m_ponder);
-            return 1;
-        }
-
 #if defined (SYZYGY_SUPPORT)
         //
         //  Probe tablebases/tt at root

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -263,15 +263,3 @@ U32 Time::getMiddleGameTimeBonus(U32 remainingTime, U32 hardLimit)
 
     return std::min(hardLimit, remainingTime);
 }
-
-bool Time::chopperMove()
-{
-    //
-    //  Prevent instant move play in time controls of 'go movetime' and 'go infinite'
-    //
-
-    if (m_infinite || m_movetime)
-        return false;
-
-    return true;
-}

--- a/src/time.h
+++ b/src/time.h
@@ -49,7 +49,6 @@ public:
     U32 getHardLimit();
     U32 getDepthLimit();
     U32 getNodesLimit();
-    bool chopperMove();
 
 private:
     void reset();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.5.0";
+const std::string VERSION = "3.5.2";
 const std::string ARCHITECTURE = " 64 "
 
 #if _BTYPE==0


### PR DESCRIPTION
http://chess.grantnet.us/test/32625/

ELO   | 3.11 +- 3.99 (95%)
SPRT  | 10.0+0.00s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 15664 W: 4287 L: 4147 D: 7230

http://chess.grantnet.us/test/32624/

ELO   | 4.25 +- 4.43 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 12008 W: 3135 L: 2988 D: 5885

http://chess.grantnet.us/test/32636/

ELO   | 14.31 +- 7.90 (95%)
SPRT  | 5.0+0.00s Threads=8 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 4057 W: 1192 L: 1025 D: 1840

bench: 17628169