### PR TITLE
3.5.4: tune razor depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -277,7 +277,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         //   razoring
         //
 
-        if (depth <= 1 && staticEval + 150 < alpha)
+        if (depth <= 2 && staticEval + 150 < alpha)
             return qSearch(alpha, beta, ply, 0);
 
         //

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.5.3";
+const std::string VERSION = "3.5.4";
 const std::string ARCHITECTURE = " 64 "
 
 #if _BTYPE==0


### PR DESCRIPTION
http://chess.grantnet.us/test/32773/

ELO   | 5.30 +- 3.50 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 19352 W: 5116 L: 4821 D: 9415

http://chess.grantnet.us/test/32777/

ELO   | 2.86 +- 2.24 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 45160 W: 11298 L: 10926 D: 22936

bench: 17469608