### PR TITLE
Add missing includes. No functional change.

### DIFF
--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -20,6 +20,7 @@
 #include "nnue.h"
 #include "position.h"
 #include "utils.h"
+#include <cstdint>
 #include <immintrin.h>
 
 #include <streambuf>

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -20,6 +20,7 @@
 #ifndef NNUE_H
 #define NNUE_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 #include <immintrin.h>

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -23,6 +23,7 @@
 #include "utils.h"
 #include "nnue.h"
 
+#include <cstdint>
 #include <memory>
 
 const Move MOVE_O_O[2]   = { Move(E1, G1, KW), Move(E8, G8, KB) };

--- a/src/position.h
+++ b/src/position.h
@@ -24,6 +24,8 @@
 #include "bitboards.h"
 #include "nnue.h"
 
+#include <cstdint>
+
 #define STD_POSITION "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 
 enum

--- a/src/types.h
+++ b/src/types.h
@@ -24,6 +24,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
+#include <cstdint>
 #include <cstring>
 #include <ctime>
 #include <deque>
@@ -35,7 +36,6 @@
 #include <vector>
 
 #ifndef _MSC_VER
-#include <stdint.h>
 typedef uint8_t U8;
 typedef uint16_t U16;
 typedef uint32_t U32;


### PR DESCRIPTION
Couple of sources files that use fixed-width integer types such as std::uint32_t are missing the include to \<cstdint\>. This breaks the build on Ubuntu 23.10 (GCC 13.2), so add the missing includes.

bench: 19300902

**

I noticed the build breakages when upgrading my openbench build container from Ubuntu 23.04 to 23.10. I'd guess that previously some of the system headers were including stdint.h/cstdint directly which hid this issue. Anyway, the fix is pretty trivial.

Fixed this by grepping 'int32_t' and adding include \<cstdint\> to files with hits, except the fathom sources. In general, it is often considered a good practice not depend on transitive includes (e.g., arguably nnue.cpp shouldn't need the include because nnue.h already does the include), so I added these also to the .cpp files even if not strictly needed.

I'll comment the one change in types.h inline.