### PR TITLE
3.5.6: implement iid

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -337,6 +337,13 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         }
     }
 
+    //
+    //  IID
+    //
+
+    if (depth >= 7 && (onPV || cutNode) && (!hashMove || hEntry.m_data.depth + 4 < depth))
+        --depth;
+
     auto legalMoves = 0;
     bestScore = -CHECKMATE_SCORE + ply;
     U8 type = HASH_ALPHA;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.5.5";
+const std::string VERSION = "3.5.6";
 const std::string ARCHITECTURE = " 64 "
 
 #if _BTYPE==0


### PR DESCRIPTION
http://chess.grantnet.us/test/37934/

Elo   | 3.95 +- 2.61 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 21462 W: 5553 L: 5309 D: 10600
Penta | [179, 2523, 5117, 2699, 213]

http://chess.grantnet.us/test/37935/

Elo   | 14.53 +- 5.17 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 4330 W: 1183 L: 1002 D: 2145
Penta | [11, 406, 1155, 577, 16]