### PR TITLE
3.5.7: use negative extensions up to minus 3

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -429,7 +429,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             else if (betaCut >= beta)
                 return betaCut;
             else if (ttHit && ttScore >= beta)
-                extension = -2; // negative extension
+                extension = -3; // negative extension
         }
 
         if (quietMove) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.5.6";
+const std::string VERSION = "3.5.7";
 const std::string ARCHITECTURE = " 64 "
 
 #if _BTYPE==0


### PR DESCRIPTION
Elo   | 2.56 +- 1.94 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
Games | N: 38278 W: 9791 L: 9509 D: 18978
Penta | [337, 4441, 9307, 4711, 343]
http://chess.grantnet.us/test/38116/