### PR TITLE
3.5.8: check beta score in probcut condition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -306,8 +306,9 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         //  probcut
         //
 
-        if (depth >= 5) {
-            auto betaCut = beta + 100;
+        auto betaCut = beta + 100;
+
+        if (depth >= 5 && !(ttHit && hEntry.m_data.depth >= (depth - 4) && hEntry.m_data.score < betaCut)) {
             MoveList captureMoves;
 
             GenCapturesAndPromotions(m_position, captureMoves);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.5.7";
+const std::string VERSION = "3.5.8";
 const std::string ARCHITECTURE = " 64 "
 
 #if _BTYPE==0


### PR DESCRIPTION
Elo   | 3.77 +- 2.43 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 19608 W: 4963 L: 4750 D: 9895
Penta | [47, 2150, 5199, 2359, 49]
http://chess.grantnet.us/test/38222/

Elo   | 1.46 +- 1.17 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
Games | N: 106578 W: 27237 L: 26789 D: 52552
Penta | [951, 12640, 25653, 13100, 945]
http://chess.grantnet.us/test/38221/

bench: 1456967