### PR TITLE
3.5.9: low bound condition in sext

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -421,7 +421,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         //  singular extensions
         //
 
-        if (depth >= 8 && !skipMove && hashMove == mv && !rootNode && !isCheckMateScore(hEntry.m_data.score) && (hEntry.m_data.type == HASH_BETA || hEntry.m_data.type == HASH_EXACT) && hEntry.m_data.depth >= depth - 3) {
+        if (depth >= 8 && !skipMove && hashMove == mv && !rootNode && !isCheckMateScore(hEntry.m_data.score) && hEntry.m_data.type == HASH_BETA && hEntry.m_data.depth >= depth - 3) {
             auto betaCut = hEntry.m_data.score - depth;
             auto score = abSearch(betaCut - 1, betaCut, depth / 2, ply + 1, false, false, cutNode, mv);
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.5.8";
+const std::string VERSION = "3.5.9";
 const std::string ARCHITECTURE = " 64 "
 
 #if _BTYPE==0


### PR DESCRIPTION
Elo   | 3.73 +- 2.51 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 22792 W: 5927 L: 5682 D: 11183
Penta | [172, 2689, 5459, 2874, 202]
http://chess.grantnet.us/test/38228/

Elo   | 2.28 +- 1.73 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 39096 W: 9770 L: 9513 D: 19813
Penta | [86, 4449, 10243, 4662, 108]
http://chess.grantnet.us/test/38230/

bench: 1217611