### PR TITLE
3.5.10: singular extension 2 on non pv moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -425,8 +425,11 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             auto betaCut = hEntry.m_data.score - depth;
             auto score = abSearch(betaCut - 1, betaCut, depth / 2, ply + 1, false, false, cutNode, mv);
 
-            if (score < betaCut)
+            if (score < betaCut) {
                 extension = 1;
+                if (!onPV && score < betaCut - 50)
+                    extension = 2;
+            }
             else if (betaCut >= beta)
                 return betaCut;
             else if (ttHit && ttScore >= beta)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.5.9";
+const std::string VERSION = "3.5.10";
 const std::string ARCHITECTURE = " 64 "
 
 #if _BTYPE==0


### PR DESCRIPTION
Elo   | 4.50 +- 2.80 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 18242 W: 4827 L: 4591 D: 8824
Penta | [166, 2063, 4403, 2347, 142]
http://chess.grantnet.us/test/38323/

Elo   | 13.63 +- 4.98 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 4590 W: 1190 L: 1010 D: 2390
Penta | [10, 433, 1234, 603, 15]
http://chess.grantnet.us/test/38327/

bench: 1202492