### PR TITLE
Release Igel 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,3 @@ or if you are running Linux:
 The 'Nodes' must match the 'BENCH :' value from the last commit message.
 
 It is also possible to compile using gcc and a traditional makefile, please consult ./src/makefile for more details.
-
-### Donation
-
-Thank you so much for supporting Igel's development and training via [![Paypal](https://raw.githubusercontent.com/vshcherbyna/igel/master/paypal3.jpg)](https://www.paypal.com/donate/?hosted_button_id=37NPEAY9XLRJE).

--- a/history.txt
+++ b/history.txt
@@ -1,7 +1,20 @@
 Igel - open source chess engine forked from GreKo 2018.01.
 
-(c) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com> (Igel author)
+(c) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com> (Igel author)
 (c) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
+
+Igel 3.6.0
+-------------
+28-Jan-2024
+
+- extend by 2 in singular extension on non pv move
+- improve low bound condition in singular extension
+- check beta score in probcut condition
+- store in TT in standing pat in qsearch
+- implement iid
+- tune null move depth
+- tune razor depth
+- remove instant moves handling
 
 Igel 3.5.0
 -------------

--- a/src/bitboards.cpp
+++ b/src/bitboards.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/bitboards.h
+++ b/src/bitboards.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/gen.h
+++ b/src/gen.h
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/moves.cpp
+++ b/src/moves.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/moves.h
+++ b/src/moves.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/notation.cpp
+++ b/src/notation.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/notation.h
+++ b/src/notation.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/position.h
+++ b/src/position.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/search.h
+++ b/src/search.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/time.h
+++ b/src/time.h
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/tt.h
+++ b/src/tt.h
@@ -1,7 +1,7 @@
 /*
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/types.h
+++ b/src/types.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -81,7 +81,7 @@ const int MAX_THREADS     = 1024;
 
 int Uci::handleCommands()
 {
-    std::cout << "Igel " << VERSION << ARCHITECTURE << " by V. Shcherbyna (Igel author 2018-2023), V. Medvedev (GreKo author 2002-2018)" << std::endl;
+    std::cout << "Igel " << VERSION << ARCHITECTURE << " by V. Shcherbyna (Igel author 2018-2025), V. Medvedev (GreKo author 2002-2018)" << std::endl;
 
     if (!TTable::instance().setHashSize(DEFAULT_HASH_SIZE, DEFAULT_THREADS)) {
         std::cout << "Fatal error: unable to allocate memory for transposition table" << std::endl;
@@ -129,7 +129,7 @@ int Uci::handleCommands()
 void Uci::onUci()
 {
     std::cout << "id name Igel " << VERSION << ARCHITECTURE << std::endl;
-    std::cout << "id author V. Shcherbyna (Igel author 2018-2023), V. Medvedev (GreKo author 2002-2018)" << std::endl;
+    std::cout << "id author V. Shcherbyna (Igel author 2018-2025), V. Medvedev (GreKo author 2002-2018)" << std::endl;
 
     std::cout << "option name Hash type spin"   <<
         " default " << DEFAULT_HASH_SIZE        <<

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,7 +2,7 @@
 *  Igel - a UCI chess playing engine derived from GreKo 2018.01
 *
 *  Copyright (C) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
-*  Copyright (C) 2018-2023 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*  Copyright (C) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
 *
 *  Igel is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Igel 3.6.0
-------------
28-Jan-2024

- extend by 2 in singular extension on non pv move
- improve low bound condition in singular extension
- check beta score in probcut condition
- store in TT in standing pat in qsearch
- implement iid
- tune null move depth
- tune razor depth
- remove instant moves handling

http://chess.grantnet.us/test/38642/

Elo   | 21.28 +- 3.60 (95%)
Conf  | 60.0+0.60s Threads=1 Hash=64MB
Games | N: 8860 W: 2461 L: 1919 D: 4480
Penta | [7, 798, 2299, 1298, 28]

http://chess.grantnet.us/test/38641/

Elo   | 20.07 +- 3.21 (95%)
Conf  | 10.0+0.10s Threads=1 Hash=8MB
Games | N: 13918 W: 3953 L: 3150 D: 6815
Penta | [76, 1392, 3306, 2023, 162]

bench: 1202492