### PR TITLE
building on osx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,12 @@ ipch/
 # Local folder
 [Ll]ocal/
 
+#CMake
+CMakeCache.txt
+CMakeFiles
+Makefile
+cmake_install.cmake
+
+network_file
+igel
+igel.exe

--- a/src/fathom/tbprobe.cpp
+++ b/src/fathom/tbprobe.cpp
@@ -899,33 +899,33 @@ bool tb_init(const char *path)
   int i, j, k, l, m;
 
   for (i = 0; i < 5; i++) {
-    sprintf(str, "K%cvK", pchr(i));
+    snprintf(str, sizeof(str), "K%cvK", pchr(i));
     init_tb(str);
   }
 
   for (i = 0; i < 5; i++)
     for (j = i; j < 5; j++) {
-      sprintf(str, "K%cvK%c", pchr(i), pchr(j));
+      snprintf(str, sizeof(str), "K%cvK%c", pchr(i), pchr(j));
       init_tb(str);
     }
 
   for (i = 0; i < 5; i++)
     for (j = i; j < 5; j++) {
-      sprintf(str, "K%c%cvK", pchr(i), pchr(j));
+      snprintf(str, sizeof(str), "K%c%cvK", pchr(i), pchr(j));
       init_tb(str);
     }
 
   for (i = 0; i < 5; i++)
     for (j = i; j < 5; j++)
       for (k = 0; k < 5; k++) {
-        sprintf(str, "K%c%cvK%c", pchr(i), pchr(j), pchr(k));
+        snprintf(str, sizeof(str), "K%c%cvK%c", pchr(i), pchr(j), pchr(k));
         init_tb(str);
       }
 
   for (i = 0; i < 5; i++)
     for (j = i; j < 5; j++)
       for (k = j; k < 5; k++) {
-        sprintf(str, "K%c%c%cvK", pchr(i), pchr(j), pchr(k));
+        snprintf(str, sizeof(str), "K%c%c%cvK", pchr(i), pchr(j), pchr(k));
         init_tb(str);
       }
 
@@ -937,7 +937,7 @@ bool tb_init(const char *path)
     for (j = i; j < 5; j++)
       for (k = i; k < 5; k++)
         for (l = (i == k) ? j : k; l < 5; l++) {
-          sprintf(str, "K%c%cvK%c%c", pchr(i), pchr(j), pchr(k), pchr(l));
+          snprintf(str, sizeof(str), "K%c%cvK%c%c", pchr(i), pchr(j), pchr(k), pchr(l));
           init_tb(str);
         }
 
@@ -945,7 +945,7 @@ bool tb_init(const char *path)
     for (j = i; j < 5; j++)
       for (k = j; k < 5; k++)
         for (l = 0; l < 5; l++) {
-          sprintf(str, "K%c%c%cvK%c", pchr(i), pchr(j), pchr(k), pchr(l));
+          snprintf(str, sizeof(str), "K%c%c%cvK%c", pchr(i), pchr(j), pchr(k), pchr(l));
           init_tb(str);
         }
 
@@ -953,7 +953,7 @@ bool tb_init(const char *path)
     for (j = i; j < 5; j++)
       for (k = j; k < 5; k++)
         for (l = k; l < 5; l++) {
-          sprintf(str, "K%c%c%c%cvK", pchr(i), pchr(j), pchr(k), pchr(l));
+          snprintf(str, sizeof(str), "K%c%c%c%cvK", pchr(i), pchr(j), pchr(k), pchr(l));
           init_tb(str);
         }
 
@@ -965,7 +965,7 @@ bool tb_init(const char *path)
       for (k = j; k < 5; k++)
         for (l = k; l < 5; l++)
           for (m = l; m < 5; m++) {
-            sprintf(str, "K%c%c%c%c%cvK", pchr(i), pchr(j), pchr(k), pchr(l), pchr(m));
+            snprintf(str, sizeof(str), "K%c%c%c%c%cvK", pchr(i), pchr(j), pchr(k), pchr(l), pchr(m));
             init_tb(str);
           }
 
@@ -974,7 +974,7 @@ bool tb_init(const char *path)
       for (k = j; k < 5; k++)
         for (l = k; l < 5; l++)
           for (m = 0; m < 5; m++) {
-            sprintf(str, "K%c%c%c%cvK%c", pchr(i), pchr(j), pchr(k), pchr(l), pchr(m));
+            snprintf(str, sizeof(str), "K%c%c%c%cvK%c", pchr(i), pchr(j), pchr(k), pchr(l), pchr(m));
             init_tb(str);
           }
 
@@ -983,7 +983,7 @@ bool tb_init(const char *path)
       for (k = j; k < 5; k++)
         for (l = 0; l < 5; l++)
           for (m = l; m < 5; m++) {
-            sprintf(str, "K%c%c%cvK%c%c", pchr(i), pchr(j), pchr(k), pchr(l), pchr(m));
+            snprintf(str, sizeof(str), "K%c%c%cvK%c%c", pchr(i), pchr(j), pchr(k), pchr(l), pchr(m));
             init_tb(str);
           }
 

--- a/src/gen.h
+++ b/src/gen.h
@@ -49,7 +49,7 @@ class GenWorker
     friend class Generator;
 
 public:
-    GenWorker() : m_exit(false), m_pFile(nullptr), m_pMutex(nullptr), m_counter(0), m_search(new Search), m_finished(true), m_maxDepth(1) {}
+    GenWorker() : m_exit(false), m_pFile(nullptr), m_pMutex(nullptr), m_counter(0), m_search(new Search), m_maxDepth(1) {}
     bool isTaskReady() { return !m_tasks.empty(); }
     void workerRoutine()
     {
@@ -195,7 +195,6 @@ private:
     std::mutex * m_pMutex;
     uint64_t m_counter;
     std::unique_ptr<Search> m_search;
-    bool m_finished;
     int m_maxDepth;
     std::vector<std::string> m_tasks;
 };
@@ -211,7 +210,6 @@ public:
 private:
     int m_maxDepth;
     int m_maxThreads;
-    int m_maxfHash;
     std::unique_ptr<std::thread[]> m_workerThreads;
     std::unique_ptr<GenWorker[]> m_workers;
 };

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -244,7 +244,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
                 //
 
                 if ((type == HASH_EXACT) || (type == HASH_ALPHA ? (score <= alpha) : (score >= beta))) {
-                    TTable::instance().record(0, score, MAX_PLY, 0, type, m_position.Hash());
+                    TTable::instance().record(0, score, MAX_PLY-1, 0, type, m_position.Hash());
                     return score;
                 }
             }


### PR DESCRIPTION
gen.h - removing unused vars
search.cpp - fix implicit conversion overflow
tbprobe.cpp - use snprintf instead of deprecated sprintf

also updated .gitignore to ignore cmake generated files along with downloaded network_file and generated binary

fixes https://github.com/vshcherbyna/igel/issues/286