### PR TITLE
3.6.1: penalize bad captures

### DIFF
--- a/src/moveeval.cpp
+++ b/src/moveeval.cpp
@@ -74,6 +74,12 @@ const EVAL SORT_VALUE[14] = { 0, 0, VAL_P, VAL_P, VAL_N, VAL_N, VAL_B, VAL_B, VA
             EVAL s_promotion = SORT_VALUE[mv.Promotion()];
 
             mvlist[j].m_score = s_SortCapture + 10 * (s_captured + s_promotion) - s_piece;
+
+            if (mv.Captured() && !mv.Promotion()) { // add SEE score for captures if it's negative (losing captures)
+                auto see = MoveEval::SEE(pSearch, mv);
+                if (see < 0)
+                    mvlist[j].m_score = s_SortBadCapture + see; // penalize bad captures, but still keep them above non-captures
+            }
         }
         else if (mv == pSearch->m_killerMoves[ply][0] || mv == pSearch->m_killerMoves[ply][1])
             mvlist[j].m_score = s_SortKiller;

--- a/src/moveeval.h
+++ b/src/moveeval.h
@@ -38,9 +38,10 @@ public:
     static EVAL SEE(Search * pSearch, const Move & mv);
 
 private:
-    static constexpr int s_SortHash = 7000000;
-    static constexpr int s_SortCapture = 6000000;
-    static constexpr int s_SortKiller = 5000000;
+    static constexpr int s_SortHash       = 7000000;
+    static constexpr int s_SortCapture    = 6000000;
+    static constexpr int s_SortKiller     = 5000000;
+    static constexpr int s_SortBadCapture = 1000000;
 };
 
 #endif // MOVEVAL_H

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.0";
+const std::string VERSION = "3.6.1";
 const std::string ARCHITECTURE = " 64 "
 
 #if _BTYPE==0


### PR DESCRIPTION
Elo   | 8.30 +- 4.00 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 8706 W: 2347 L: 2139 D: 4220
Penta | [61, 945, 2150, 1119, 78]
http://chess.grantnet.us/test/39221/

Elo   | 2.89 +- 2.04 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 27406 W: 6907 L: 6679 D: 13820
Penta | [50, 3036, 7308, 3254, 55]
http://chess.grantnet.us/test/39222/

bench: 1169306