### PR TITLE
3.6.2: optimize move sorting

### DIFF
--- a/src/moveeval.cpp
+++ b/src/moveeval.cpp
@@ -100,12 +100,21 @@ const EVAL SORT_VALUE[14] = { 0, 0, VAL_P, VAL_P, VAL_N, VAL_N, VAL_B, VAL_B, VA
     if (i == 0 && mvlist[0].m_score == s_SortHash)
         return mvlist[0].m_mv;
 
-    auto mvSize = mvlist.Size();
-    for (size_t j = i + 1; j < mvSize; ++j)
-    {
-        if (mvlist[j].m_score > mvlist[i].m_score)
-            std::swap(mvlist[i], mvlist[j]);
+    size_t best_idx = i;
+    int best_score = mvlist[i].m_score;
+
+    // find the move with the highest score
+    for (size_t j = i + 1; j < mvlist.Size(); ++j) {
+        if (mvlist[j].m_score > best_score) {
+            best_idx = j;
+            best_score = mvlist[j].m_score;
+        }
     }
+
+    // if we found a better move, do a single swap
+    if (best_idx != i)
+        std::swap(mvlist[i], mvlist[best_idx]);
+
     return mvlist[i].m_mv;
 }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.1";
+const std::string VERSION = "3.6.2";
 const std::string ARCHITECTURE = " 64 "
 
 #if _BTYPE==0


### PR DESCRIPTION
Elo   | 25.11 +- 7.23 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 2772 W: 843 L: 643 D: 1286
Penta | [11, 272, 645, 422, 36]
http://chess.grantnet.us/test/39241/

Elo   | 5.19 +- 2.93 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 13334 W: 3419 L: 3220 D: 6695
Penta | [22, 1459, 3506, 1658, 22]
http://chess.grantnet.us/test/39242/

bench: 1177845