### PR TITLE
3.6.3: support longer games

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -189,7 +189,7 @@ private:
     int   m_ply;
     COLOR m_side;
 
-    enum { MAX_UNDO = 1024 };
+    enum { MAX_UNDO = 2048 };
     Undo m_undos[MAX_UNDO];
     int m_undoSize;
     bool m_initialPosition;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.2";
+const std::string VERSION = "3.6.3";
 const std::string ARCHITECTURE = " 64 "
 
 #if _BTYPE==0


### PR DESCRIPTION
Elo   | 1.86 +- 2.56 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 19608 W: 5067 L: 4962 D: 9579
Penta | [119, 2173, 5124, 2260, 128]
http://chess.grantnet.us/test/39442/

Elo   | -3.17 +- 4.96 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | -0.87 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 5146 W: 1302 L: 1349 D: 2495
Penta | [23, 635, 1302, 592, 21]
http://chess.grantnet.us/test/39443/

bench: 1177845