### PR TITLE
Fix TT catling bit for frc

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -46,6 +46,13 @@ void TTable::record(Move mv, EVAL score, I8 depth, int ply, U8 type, U64 hash0)
     TTCluster & cluster = m_hash[index];
     auto * replaceEntry = &cluster.entry[0];
 
+    //
+    // m_data.age is a 7-bit field, so reduce the generation counter the same way
+    // before comparing; this lets the counter wrap cleanly every 128 generations
+    //
+
+    const U8 curAge = static_cast<U8>(m_hashAge & 0x7F);
+
     for (auto i = 0; i < 4; ++i) {
         // empty bucket or a matched hash
         if ((!cluster.entry[i].m_key) || ((cluster.entry[i].m_key ^ cluster.entry[i].m_data.raw) == hash0)) {
@@ -53,7 +60,7 @@ void TTable::record(Move mv, EVAL score, I8 depth, int ply, U8 type, U64 hash0)
             break;
         }
 
-        if ((cluster.entry[i].m_data.age == m_hashAge) - (replaceEntry->m_data.age == m_hashAge) - (cluster.entry[i].m_data.depth < replaceEntry->m_data.depth) < 0)
+        if ((cluster.entry[i].m_data.age == curAge) - (replaceEntry->m_data.age == curAge) - (cluster.entry[i].m_data.depth < replaceEntry->m_data.depth) < 0)
             replaceEntry = &cluster.entry[i];
     }
 
@@ -63,7 +70,7 @@ void TTable::record(Move mv, EVAL score, I8 depth, int ply, U8 type, U64 hash0)
     if (score < -CHECKMATE_SCORE + 50 && score >= -CHECKMATE_SCORE)
         score -= ply;
 
-    replaceEntry->store(mv, score, depth, type, hash0, m_hashAge);
+    replaceEntry->store(mv, score, depth, type, hash0, curAge);
 }
 
 bool TTable::retrieve(U64 hash, TEntry & hentry)

--- a/src/tt.h
+++ b/src/tt.h
@@ -27,7 +27,7 @@ class TEntry
 public:
     typedef union {
         struct {
-            U32 move:24, age:8, type:2;
+            U32 move:25, age:7, type:2;
             I32 score:22, depth:8;
         };
         U64 raw;
@@ -48,7 +48,7 @@ public:
         assert(age >= 0 && age <= 255);
         assert(depth >= -128 && depth <= 127);
         assert(score >= -50000 && score <= 50000);
-        assert(mv >= 0 && mv <= 16777216);
+        assert(mv >= 0 && mv <= 33554431);
 
         m_data.age   = age;
         m_data.type  = type;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.9";
+const std::string VERSION = "3.6.10";
 const std::string ARCHITECTURE = " 64 "
 
 #if _BTYPE==0

--- a/src/unit/test_tt.cpp
+++ b/src/unit/test_tt.cpp
@@ -149,7 +149,7 @@ TEST(TranspositionTableEntryAgeTest, Positive)
     te.store(0, 0, 0, 0, 0, 0);
     EXPECT_EQ(0, te.m_data.age);
 
-    for (auto i = 0; i < 255; ++i) {
+    for (auto i = 0; i < 128; ++i) {
         te.store(0, 0, 0, 0, 0, i);
         EXPECT_EQ(i, te.m_data.age);
     }
@@ -192,8 +192,7 @@ TEST(TranspositionTableEntryCompositeTest, Positive)
     EXPECT_EQ(1, te.m_data.depth);
     EXPECT_EQ(-CHECKMATE_SCORE, te.m_data.score);
 
-     // move range
-    for (auto i = 0; i <= 16777215; ++i) {
+    for (auto i = 0; i <= 33554431; ++i) {
         te.store(i, CHECKMATE_SCORE, 1, 1, 1, 1);
         EXPECT_EQ(i, te.m_data.move);
         EXPECT_EQ(CHECKMATE_SCORE, te.m_data.score);
@@ -202,7 +201,6 @@ TEST(TranspositionTableEntryCompositeTest, Positive)
         EXPECT_EQ(1, te.m_data.type);
     }
 
-     // depth range
     for (auto i = -128; i <= 127; ++i) {
         te.store(16777215, -CHECKMATE_SCORE, i, 1, 1, 1);
         EXPECT_EQ(i, te.m_data.depth);
@@ -212,7 +210,6 @@ TEST(TranspositionTableEntryCompositeTest, Positive)
         EXPECT_EQ(-CHECKMATE_SCORE, te.m_data.score);
     }
 
-    // score range
     for (auto i = -CHECKMATE_SCORE + 128; i <= CHECKMATE_SCORE + 128; ++i) {
         te.store(16777215, i, 1, 1, 1, 1);
         EXPECT_EQ(i, te.m_data.score);
@@ -222,7 +219,6 @@ TEST(TranspositionTableEntryCompositeTest, Positive)
         EXPECT_EQ(16777215, te.m_data.move);
     }
 
-    // type range
     for (auto i = 0; i < 3; ++i) {
         te.store(16777215, 1, 1, i, 1, 1);
         EXPECT_EQ(i, te.m_data.type);
@@ -232,8 +228,7 @@ TEST(TranspositionTableEntryCompositeTest, Positive)
         EXPECT_EQ(16777215, te.m_data.move);
     }
 
-    // age range
-    for (auto i = 0; i < 255; ++i) {
+    for (auto i = 0; i < 128; ++i) {
         te.store(16777215, 1, 1, 1, 1, i);
         EXPECT_EQ(i, te.m_data.age);
         EXPECT_EQ(1, te.m_data.type);


### PR DESCRIPTION
Elo   | 2.57 +- 3.04 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 16216 W: 3056 L: 2936 D: 10224
Penta | [220, 1683, 4185, 1797, 223]
https://chess.grantnet.us/test/40643/

Elo   | 0.35 +- 1.55 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 54722 W: 14226 L: 14171 D: 26325
Penta | [407, 6133, 14232, 6176, 413]
https://chess.grantnet.us/test/40639/

Elo   | 3.90 +- 3.36 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 10058 W: 1610 L: 1497 D: 6951
Penta | [53, 936, 2964, 997, 79]
https://chess.grantnet.us/test/40648/

Elo   | 4.23 +- 3.56 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 9688 W: 2554 L: 2436 D: 4698
Penta | [41, 1061, 2524, 1175, 43]
https://chess.grantnet.us/test/40649/

bench: 1354500