### PR TITLE
clang

### DIFF
--- a/.github/workflows/build-linux-pgo-clang.yml
+++ b/.github/workflows/build-linux-pgo-clang.yml
@@ -1,0 +1,37 @@
+name: Igel Linux Build PGO Clang
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:  # Allow manual triggering of the workflow
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Install Clang 19 toolchain
+      run: |
+        # clang-19 + lld-19 + llvm-19 (llvm-profdata-19) + the compiler-rt
+        # instrumentation runtime (libclang-rt-19-dev) needed by -fprofile-generate
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 19
+        sudo apt-get install -y clang-19 lld-19 llvm-19 libclang-rt-19-dev
+
+    - name: Run make pgoclang
+      run: cd src&&make pgoclang
+
+    - name: Run the bench
+      run: cd src&&./igel bench

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,12 @@ IF (DEFINED _MAKE_UNIT_TEST)
 ELSE()
     IF (UNIX)
         ADD_DEFINITIONS(-DNDEBUG)
-        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -O3 -march=native -flto=auto -funroll-loops -pthread -mavx2")
+        IF (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+            # Clang rejects gcc's -flto=auto and needs an LTO-capable linker (lld).
+            SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O3 -march=native -flto -fuse-ld=lld-19 -funroll-loops -pthread -mavx2")
+        ELSE()
+            SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -O3 -march=native -flto=auto -funroll-loops -pthread -mavx2")
+        ENDIF()
         IF (DEFINED USE_AVX512)
             SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx512f -mavx512bw")
             IF (DEFINED USE_VNNI)
@@ -79,5 +84,50 @@ ELSE()
             ENDIF()
         ENDIF()
     ENDIF (UNIX)
-    ADD_EXECUTABLE(igel ${SRCFILES} ${HDRFILES} ${FATHOM_SRCFILES} ${FATHOM_HDRFILES} ${INCBIN_HDRFILES})
+
+    SET(IGEL_SOURCES ${SRCFILES} ${HDRFILES} ${FATHOM_SRCFILES} ${FATHOM_HDRFILES} ${INCBIN_HDRFILES})
+
+    IF (DEFINED PGO)
+        #
+        #  Profile-Guided Optimization (Clang IRPGO + full LTO).
+        #  A single 'make' does the whole cycle: build an instrumented binary,
+        #  train it on 'bench', merge the profile, then rebuild 'igel' with it.
+        #
+        IF (NOT UNIX OR NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+            MESSAGE(FATAL_ERROR "PGO build supports Clang on UNIX. Re-run cmake with -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++")
+        ENDIF()
+
+        FIND_PROGRAM(LLVM_PROFDATA NAMES llvm-profdata-19 llvm-profdata)
+        IF (NOT LLVM_PROFDATA)
+            MESSAGE(FATAL_ERROR "llvm-profdata not found - install the matching LLVM tools (e.g. llvm-19) for a PGO build")
+        ENDIF()
+
+        SET(PGO_DIR  ${CMAKE_BINARY_DIR}/pgo)
+        SET(PGO_RAW  ${PGO_DIR}/igel.profraw)
+        SET(PGO_DATA ${PGO_DIR}/igel.profdata)
+        FILE(MAKE_DIRECTORY ${PGO_DIR})
+
+        # Stage 1: instrumented binary (kept out of 'all'; built on demand below).
+        ADD_EXECUTABLE(igel_instrumented EXCLUDE_FROM_ALL ${IGEL_SOURCES})
+        TARGET_COMPILE_OPTIONS(igel_instrumented PRIVATE -fprofile-generate)
+        SET_TARGET_PROPERTIES(igel_instrumented PROPERTIES LINK_FLAGS "-fprofile-generate")
+
+        # Stage 2: train on 'bench' and merge the raw counters into a .profdata.
+        ADD_CUSTOM_COMMAND(
+            OUTPUT ${PGO_DATA}
+            COMMAND ${CMAKE_COMMAND} -E rm -f ${PGO_RAW} ${PGO_DATA}
+            COMMAND ${CMAKE_COMMAND} -E env LLVM_PROFILE_FILE=${PGO_RAW} $<TARGET_FILE:igel_instrumented> bench
+            COMMAND ${LLVM_PROFDATA} merge -output=${PGO_DATA} ${PGO_RAW}
+            DEPENDS igel_instrumented
+            COMMENT "PGO: training on bench and merging profile"
+            VERBATIM)
+        ADD_CUSTOM_TARGET(igel_pgo_profile DEPENDS ${PGO_DATA})
+
+        # Stage 3: the real 'igel', optimized with the collected profile.
+        ADD_EXECUTABLE(igel ${IGEL_SOURCES})
+        TARGET_COMPILE_OPTIONS(igel PRIVATE -fprofile-use=${PGO_DATA} -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date)
+        ADD_DEPENDENCIES(igel igel_pgo_profile)
+    ELSE()
+        ADD_EXECUTABLE(igel ${IGEL_SOURCES})
+    ENDIF()
 ENDIF()

--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ cmake -DEVALFILE=network_file -DUSE_AVX2=1 -DUSE_AVX512=1 -DUSE_VNNI=1 -D_BTYPE=
 make -j
 ```
 
+On Linux you can also build with clang and full LTO, optionally with Profile-Guided Optimization (PGO) for the fastest binary. This needs clang, the lld linker and llvm-profdata from the LLVM 19 toolchain (on Debian/Ubuntu also install the instrumentation runtime, e.g. `libclang-rt-19-dev`). Add -DPGO=1 and a single `make` runs the whole cycle automatically: it builds an instrumented Igel, trains it on `bench`, merges the profile and rebuilds Igel with it.
+
+```
+git clone https://github.com/vshcherbyna/igel.git ./igel
+cd igel
+git submodule update --init --recursive
+wget https://github.com/vshcherbyna/igel/releases/download/3.5.0/c049c117 -O ./network_file
+cmake -DPGO=1 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DEVALFILE=network_file -DUSE_AVX2=1 -DUSE_AVX512=1 -DUSE_VNNI=1 -D_BTYPE=1 -DSYZYGY_SUPPORT=TRUE .
+make -j
+```
+
+Omit -DPGO=1 for a plain clang full-LTO build.
+
 Important! If you make a custom build of Igel you need to validate the bench using command:
 
 ```

--- a/src/makefile
+++ b/src/makefile
@@ -33,6 +33,17 @@ endif
 
 CFLAGS = $(WARN) $(LIBS) $(OPTIM) $(NNFLAGS)
 
+#
+# Clang full-LTO + PGO build settings (used by the pgoclang target below).
+# Clang rejects gcc's -flto=auto and links LTO through lld. Override
+# CLANGCC / CLANGLD / PROFDATA if your toolchain uses unversioned names.
+#
+CLANGCC    = clang++-19
+CLANGLD    = lld-19
+PROFDATA   = llvm-profdata-19
+CLANGOPTIM = -O3 -march=native -flto -fuse-ld=$(CLANGLD) -funroll-loops
+CLANGFLAGS = $(WARN) $(LIBS) $(CLANGOPTIM) $(NNFLAGS)
+
 basic:
 	$(CC) $(CFLAGS) $(SRC) $(DEFS) -o $(EXE)
 
@@ -49,6 +60,18 @@ else ifeq ($(findstring clang, $(CC)), clang)
 	$(CC) $(CFLAGS) $(SRC) $(DEFS) -fprofile-instr-use=igel.profdata -o $(EXE)
 	@rm -rf pgo pgo.out igel.profdata *.profraw
 endif
+
+#
+# Clang full-LTO + Profile-Guided Optimization build (sibling of 'pgo').
+# A single 'make pgoclang' builds an instrumented binary, trains it on
+# bench, merges the profile with llvm-profdata, then rebuilds with it.
+#
+pgoclang: download-network
+	$(CLANGCC) $(CLANGFLAGS) $(SRC) $(DEFS) -fprofile-generate -o $(EXE)
+	LLVM_PROFILE_FILE=igel.profraw ./$(EXE) bench 15 > pgo.out 2>&1
+	$(PROFDATA) merge -output=igel.profdata igel.profraw
+	$(CLANGCC) $(CLANGFLAGS) $(SRC) $(DEFS) -fprofile-use=igel.profdata -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date -o $(EXE)
+	@rm -rf igel.profraw igel.profdata pgo.out default*.profraw
 
 download-network:
 	mkdir weights; \


### PR DESCRIPTION
Implement clang support in CMake and makefile. Compared to gcc the clang pgo results in 6% NPS improvement.

bench: 1354500
