### PR TITLE
3.6.14: release new standard network

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,16 @@
 cmake_minimum_required (VERSION 3.7)
+
+#
+#  A PGO build (-DPGO=1) is Clang full-LTO + Profile-Guided Optimization, the
+#  same recipe as 'make pgoclang' in src/makefile. Select the LLVM 19 toolchain
+#  automatically so -DPGO=1 needs no extra flags; an explicit
+#  -DCMAKE_CXX_COMPILER=... still wins. Configure a PGO build in a clean tree.
+#
+IF (PGO AND NOT DEFINED CMAKE_CXX_COMPILER)
+    SET(CMAKE_C_COMPILER   clang-19)
+    SET(CMAKE_CXX_COMPILER clang++-19)
+ENDIF()
+
 SET(CMAKE_CXX_STANDARD 17)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 SET(CMAKE_CXX_EXTENSIONS OFF)
@@ -87,46 +99,46 @@ ELSE()
 
     SET(IGEL_SOURCES ${SRCFILES} ${HDRFILES} ${FATHOM_SRCFILES} ${FATHOM_HDRFILES} ${INCBIN_HDRFILES})
 
-    IF (DEFINED PGO)
+    IF (PGO)
         #
-        #  Profile-Guided Optimization (Clang IRPGO + full LTO).
-        #  A single 'make' does the whole cycle: build an instrumented binary,
-        #  train it on 'bench', merge the profile, then rebuild 'igel' with it.
+        #  Profile-Guided Optimization: the same four steps as 'make pgoclang'
+        #  in src/makefile, run by a single 'make'. The clang full-LTO flags and
+        #  the LLVM 19 toolchain are set above, so only the profile flags differ
+        #  between the instrumented and the final build.
         #
         IF (NOT UNIX OR NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-            MESSAGE(FATAL_ERROR "PGO build supports Clang on UNIX. Re-run cmake with -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++")
+            MESSAGE(FATAL_ERROR "PGO is a Clang-on-UNIX build; install the LLVM 19 toolchain (clang-19, lld-19, llvm-profdata-19) and configure in a clean tree.")
         ENDIF()
 
         FIND_PROGRAM(LLVM_PROFDATA NAMES llvm-profdata-19 llvm-profdata)
         IF (NOT LLVM_PROFDATA)
-            MESSAGE(FATAL_ERROR "llvm-profdata not found - install the matching LLVM tools (e.g. llvm-19) for a PGO build")
+            MESSAGE(FATAL_ERROR "llvm-profdata not found - install the LLVM 19 tools for a PGO build")
         ENDIF()
 
-        SET(PGO_DIR  ${CMAKE_BINARY_DIR}/pgo)
-        SET(PGO_RAW  ${PGO_DIR}/igel.profraw)
-        SET(PGO_DATA ${PGO_DIR}/igel.profdata)
-        FILE(MAKE_DIRECTORY ${PGO_DIR})
+        SET(PGO_RAW  ${CMAKE_BINARY_DIR}/igel.profraw)
+        SET(PGO_DATA ${CMAKE_BINARY_DIR}/igel.profdata)
 
-        # Stage 1: instrumented binary (kept out of 'all'; built on demand below).
+        # 1. Build an instrumented igel (-fprofile-generate); kept out of 'all'.
         ADD_EXECUTABLE(igel_instrumented EXCLUDE_FROM_ALL ${IGEL_SOURCES})
         TARGET_COMPILE_OPTIONS(igel_instrumented PRIVATE -fprofile-generate)
         SET_TARGET_PROPERTIES(igel_instrumented PROPERTIES LINK_FLAGS "-fprofile-generate")
 
-        # Stage 2: train on 'bench' and merge the raw counters into a .profdata.
+        # 2. Train it on 'bench' and 3. merge the counters into igel.profdata.
         ADD_CUSTOM_COMMAND(
             OUTPUT ${PGO_DATA}
-            COMMAND ${CMAKE_COMMAND} -E rm -f ${PGO_RAW} ${PGO_DATA}
-            COMMAND ${CMAKE_COMMAND} -E env LLVM_PROFILE_FILE=${PGO_RAW} $<TARGET_FILE:igel_instrumented> bench
+            COMMAND ${CMAKE_COMMAND} -E env LLVM_PROFILE_FILE=${PGO_RAW} $<TARGET_FILE:igel_instrumented> bench 15
             COMMAND ${LLVM_PROFDATA} merge -output=${PGO_DATA} ${PGO_RAW}
             DEPENDS igel_instrumented
             COMMENT "PGO: training on bench and merging profile"
             VERBATIM)
-        ADD_CUSTOM_TARGET(igel_pgo_profile DEPENDS ${PGO_DATA})
+        ADD_CUSTOM_TARGET(igel_profile DEPENDS ${PGO_DATA})
 
-        # Stage 3: the real 'igel', optimized with the collected profile.
+        # 4. Rebuild the real igel with the profile (-fprofile-use), at compile
+        #    and link so full-LTO code generation uses it too.
         ADD_EXECUTABLE(igel ${IGEL_SOURCES})
+        ADD_DEPENDENCIES(igel igel_profile)
         TARGET_COMPILE_OPTIONS(igel PRIVATE -fprofile-use=${PGO_DATA} -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date)
-        ADD_DEPENDENCIES(igel igel_pgo_profile)
+        SET_TARGET_PROPERTIES(igel PROPERTIES LINK_FLAGS "-fprofile-use=${PGO_DATA}")
     ELSE()
         ADD_EXECUTABLE(igel ${IGEL_SOURCES})
     ENDIF()

--- a/README.md
+++ b/README.md
@@ -76,18 +76,18 @@ cmake -DEVALFILE=network_file -DUSE_AVX2=1 -DUSE_AVX512=1 -DUSE_VNNI=1 -D_BTYPE=
 make -j
 ```
 
-On Linux you can also build with clang and full LTO, optionally with Profile-Guided Optimization (PGO) for the fastest binary. This needs clang, the lld linker and llvm-profdata from the LLVM 19 toolchain (on Debian/Ubuntu also install the instrumentation runtime, e.g. `libclang-rt-19-dev`). Add -DPGO=1 and a single `make` runs the whole cycle automatically: it builds an instrumented Igel, trains it on `bench`, merges the profile and rebuilds Igel with it.
+On Linux you can also build with clang and full LTO, optionally with Profile-Guided Optimization (PGO) for the fastest binary. This uses the LLVM 19 toolchain - clang-19, the lld-19 linker and llvm-profdata-19 (on Debian/Ubuntu also install the instrumentation runtime, e.g. `libclang-rt-19-dev`) - which -DPGO=1 selects automatically, so no compiler flags are needed. A single `make` then runs the whole cycle: it builds an instrumented Igel, trains it on `bench`, merges the profile and rebuilds Igel with it.
 
 ```
 git clone https://github.com/vshcherbyna/igel.git ./igel
 cd igel
 git submodule update --init --recursive
 wget https://github.com/vshcherbyna/igel/releases/download/3.5.0/c049c117 -O ./network_file
-cmake -DPGO=1 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DEVALFILE=network_file -DUSE_AVX2=1 -DUSE_AVX512=1 -DUSE_VNNI=1 -D_BTYPE=1 -DSYZYGY_SUPPORT=TRUE .
+cmake -DPGO=1 -DEVALFILE=network_file -DUSE_AVX2=1 -DUSE_AVX512=1 -DUSE_VNNI=1 -D_BTYPE=1 -DSYZYGY_SUPPORT=TRUE .
 make -j
 ```
 
-Omit -DPGO=1 for a plain clang full-LTO build.
+Omit -DPGO=1 (and add -DCMAKE_C_COMPILER=clang-19 -DCMAKE_CXX_COMPILER=clang++-19) for a plain clang full-LTO build.
 
 Important! If you make a custom build of Igel you need to validate the bench using command:
 

--- a/src/makefile
+++ b/src/makefile
@@ -6,9 +6,16 @@ CC  = g++
 EXE = igel
 SRC = *.cpp fathom/tbprobe.cpp
 
+#
+# NNUE network: embedded via INCBIN at compile time, and fetched by the
+# $(EVALFILE) rule below if it is missing. Change these to switch networks.
+#
+
+EVALFILE    = weights/3.6.14.nnue
+NETWORK_URL = https://github.com/vshcherbyna/igel/releases/download/0.8/3.6.14.nnue
+
 GCCDEFINES = $(shell echo | $(CC) -m64 -march=native -E -dM -)
 
-EVALFILE = weights/c049c117
 NNFLAGS  = -DEVALFILE=\"$(EVALFILE)\"
 
 LIBS   = -std=c++17 -mpopcnt -pthread -lstdc++ -lm
@@ -38,6 +45,7 @@ CFLAGS = $(WARN) $(LIBS) $(OPTIM) $(NNFLAGS)
 # Clang rejects gcc's -flto=auto and links LTO through lld. Override
 # CLANGCC / CLANGLD / PROFDATA if your toolchain uses unversioned names.
 #
+
 CLANGCC    = clang++-19
 CLANGLD    = lld-19
 PROFDATA   = llvm-profdata-19
@@ -47,7 +55,7 @@ CLANGFLAGS = $(WARN) $(LIBS) $(CLANGOPTIM) $(NNFLAGS)
 basic:
 	$(CC) $(CFLAGS) $(SRC) $(DEFS) -o $(EXE)
 
-pgo: download-network
+pgo: $(EVALFILE)
 ifeq ($(findstring g++, $(CC)), g++)
 	$(CC) $(CFLAGS) $(SRC) $(DEFS) -fprofile-generate=pgo -o $(EXE)
 	./$(EXE) bench 15 > pgo.out 2>&1
@@ -66,7 +74,8 @@ endif
 # A single 'make pgoclang' builds an instrumented binary, trains it on
 # bench, merges the profile with llvm-profdata, then rebuilds with it.
 #
-pgoclang: download-network
+
+pgoclang: $(EVALFILE)
 	$(CLANGCC) $(CLANGFLAGS) $(SRC) $(DEFS) -fprofile-generate -o $(EXE)
 	LLVM_PROFILE_FILE=igel.profraw ./$(EXE) bench 15 > pgo.out 2>&1
 	$(PROFDATA) merge -output=igel.profdata igel.profraw
@@ -75,9 +84,10 @@ pgoclang: download-network
 
 #
 # Same as the pgoclang target but builds the pure hand-crafted evaluator
-# (-DPURE_HCE). The HCE engine embeds no NNUE network, so there is no
-# download-network step.
+# (-DPURE_HCE). The HCE engine embeds no NNUE network, so it needs no
+# $(EVALFILE) prerequisite.
 #
+
 pgoclanghce:
 	$(CLANGCC) $(CLANGFLAGS) $(SRC) $(DEFS) -DPURE_HCE -fprofile-generate -o $(EXE)
 	LLVM_PROFILE_FILE=igel.profraw ./$(EXE) bench 15 > pgo.out 2>&1
@@ -85,6 +95,14 @@ pgoclanghce:
 	$(CLANGCC) $(CLANGFLAGS) $(SRC) $(DEFS) -DPURE_HCE -fprofile-use=igel.profdata -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date -o $(EXE)
 	@rm -rf igel.profraw igel.profdata pgo.out default*.profraw
 
-download-network:
-	mkdir weights; \
-	echo "Downloading latest Igel network with wget"; wget -P weights https://github.com/vshcherbyna/igel/releases/download/3.5.0/c049c117;
+#
+# Fetch the NNUE network once, only if it is missing (fresh checkout or CI). A
+# failed or interrupted download is removed by .DELETE_ON_ERROR and retried on
+# the next run, so a truncated network is never embedded.
+#
+
+.DELETE_ON_ERROR:
+
+$(EVALFILE):
+	mkdir -p $(dir $@)
+	wget -O $@ $(NETWORK_URL)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.13";
+const std::string VERSION = "3.6.14";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
VSTC

Score of new-nn-epoch_1159.nnue vs base-embedded: 1189 - 999 - 2169  [0.522] 4357
...      new-nn-epoch_1159.nnue playing White: 718 - 372 - 1088  [0.579] 2178
...      new-nn-epoch_1159.nnue playing Black: 471 - 627 - 1081  [0.464] 2179
...      White vs Black: 1345 - 843 - 2169  [0.558] 4357
Elo difference: 15.2 +/- 7.3, LOS: 100.0 %, DrawRatio: 49.8 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted

STC

Score of new-nn-epoch_1159.nnue vs base-embedded: 4563 - 4327 - 24797  [0.504] 33687
...      new-nn-epoch_1159.nnue playing White: 3484 - 1161 - 12199  [0.569] 16844
...      new-nn-epoch_1159.nnue playing Black: 1079 - 3166 - 12598  [0.438] 16843
...      White vs Black: 6650 - 2240 - 24797  [0.565] 33687
Elo difference: 2.4 +/- 1.9, LOS: 99.4 %, DrawRatio: 73.6 %
SPRT: llr 2.96 (100.6%), lbound -2.94, ubound 2.94 - H1 was accepted

LTC

Score of new-nn-epoch_1159.nnue vs base-embedded: 665 - 577 - 6595  [0.506] 7837
...      new-nn-epoch_1159.nnue playing White: 555 - 102 - 3262  [0.558] 3919
...      new-nn-epoch_1159.nnue playing Black: 110 - 475 - 3333  [0.453] 3918
...      White vs Black: 1030 - 212 - 6595  [0.552] 7837
Elo difference: 3.9 +/- 3.1, LOS: 99.4 %, DrawRatio: 84.2 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted

VLTC

Score of Igel 3.6.13-1159 64 BMI2 AVX512 VNNI512 vs Igel 3.6.13 64 BMI2 AVX512 VNNI512: 515 - 437 - 5829  [0.506] 6781
...      Igel 3.6.13-1159 64 BMI2 AVX512 VNNI512 playing White: 465 - 76 - 2851  [0.557] 3392
...      Igel 3.6.13-1159 64 BMI2 AVX512 VNNI512 playing Black: 50 - 361 - 2978  [0.454] 3389
...      White vs Black: 826 - 126 - 5829  [0.552] 6781
Elo difference: 4.0 +/- 3.1, LOS: 99.4 %, DrawRatio: 86.0 %
SPRT: llr 3 (102.0%), lbound -2.94, ubound 2.94 - H1 was accepted

bench: 1357271