### PR TITLE
3.6.15: use tt for null moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -170,7 +170,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
     EVAL ttScore = 0;
     auto onPV    = (beta - alpha > 1);
-    auto ttHit   = !skipMove && !isNull && ProbeHash(hEntry, hash);
+    auto ttHit   = !skipMove && ProbeHash(hEntry, hash);
 
     if (ttHit) {
         ttScore = hEntry.m_data.score;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.14";
+const std::string VERSION = "3.6.15";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
2026-07-10 13:57:49 | [igel-04-tt-probe-after-null] VSTC PASSED (verdict H1): 7188 games +1725 -1539 =3924, LLR 2.95, Elo 9.0 +/- 5.4, 20m 52s -> starting STC
2026-07-10 13:57:49 | [igel-04-tt-probe-after-null] STC SPRT start vs 'igel-base'  tc=all/6+0.06 bounds=[0.0, 3.0]  (003_stc_igel-04-tt-probe-after-null)
2026-07-10 18:40:51 | [igel-04-tt-probe-after-null] STC match health: clean  [16359 games decided]
2026-07-10 18:40:51 | [igel-04-tt-probe-after-null] STC PASSED (verdict H1): 16345 games +2017 -1865 =12463, LLR 2.96, Elo 3.2 +/- 2.6, 4h 43m -> starting LTC
2026-07-10 18:40:51 | [igel-04-tt-probe-after-null] LTC SPRT start vs 'igel-base'  tc=all/36+0.36 bounds=[0.0, 3.0]  (004_ltc_igel-04-tt-probe-after-null)
2026-07-11 05:08:10 | [igel-04-tt-probe-after-null] LTC match health: clean  [6241 games decided]
2026-07-11 05:08:10 | [igel-04-tt-probe-after-null] LTC PASSED (verdict H1): 6227 games +551 -468 =5208, LLR 2.97, Elo 4.6 +/- 3.5, 10h 27m -> PROMOTED, base engine is now 'igel-04-tt-probe-after-null'

bench: 1360022