### PR TITLE
3.6.16: track best move stability

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1064,6 +1064,9 @@ uint64_t Search::startSearch(Time time, int depth, bool ponderSearch, bool bench
     uint64_t sumHits = 0;
     uint64_t nps = 0;
 
+    Move prevBest{};
+    int bestMoveStability = 0;
+
     for (m_depth = depth; m_depth < maxDepth; ++m_depth) {
 
         //
@@ -1111,6 +1114,17 @@ uint64_t Search::startSearch(Time time, int depth, bool ponderSearch, bool bench
             break;
 
         //
+        //  Track how many consecutive iterations kept the same best move
+        //
+
+        if (m_best && m_best == prevBest)
+            bestMoveStability = std::min(bestMoveStability + 1, 10);
+        else {
+            prevBest = m_best;
+            bestMoveStability = 0;
+        }
+
+        //
         //  Update node statistic from all workers
         //
 
@@ -1136,7 +1150,14 @@ uint64_t Search::startSearch(Time time, int depth, bool ponderSearch, bool bench
         if (dt > 1000)
             nps = 1000 * sumNodes / dt;
 
-        if (m_time.getTimeMode() == Time::TimeControl::TimeLimit && dt >= m_time.getSoftLimit()) {
+        //
+        //  Scale the soft limit by best move stability: an unsettled search earns more
+        //  time while a best move stable for many iterations is released early
+        //
+
+        U64 softLimit = static_cast<U64>(m_time.getSoftLimit()) * (130 - 5 * bestMoveStability) / 100;
+
+        if (m_time.getTimeMode() == Time::TimeControl::TimeLimit && dt >= softLimit) {
             m_flags |= TERMINATED_BY_LIMIT;
             break;
         }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.15";
+const std::string VERSION = "3.6.16";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
VSTC PASSED (verdict H1): 7157 games +1724 -1537 =3896, LLR 2.96, Elo 9.1 +/- 5.4, 20m 42s -> starting STC
STC PASSED (verdict H1): 4105 games +517 -421 =3167, LLR 2.97, Elo 8.1 +/- 5.1, 1h 10m -> starting LTC
LTC PASSED (verdict H1): 3276 games +241 -183 =2852, LLR 2.95, Elo 6.2 +/- 4.3, 5h 23m

Regression check on moves/time (40 moves in 10 seconds)

Score of Igel 3.6.16 64 POPCNT AVX512 VNNI512 vs Igel 3.6.15 64 POPCNT AVX512 VNNI512: 1060 - 1016 - 5929  [0.503] 8005
...      Igel 3.6.16 64 POPCNT AVX512 VNNI512 playing White: 816 - 228 - 2959  [0.573] 4003
...      Igel 3.6.16 64 POPCNT AVX512 VNNI512 playing Black: 244 - 788 - 2970  [0.432] 4002
...      White vs Black: 1604 - 472 - 5929  [0.571] 8005
Elo difference: 1.9 +/- 3.9, LOS: 83.3 %, DrawRatio: 74.1 %
SPRT: llr 2.98 (101.1%), lbound -2.94, ubound 2.94 - H1 was accepted

bench: 1360022