### PR TITLE
3.6.17: implement counter move table

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -73,6 +73,9 @@
 
 /*static */void History::setKillerMove(Search * pSearch, Move mv, int ply)
 {
+    if (ply >= 1 && pSearch->m_moveStack[ply - 1])
+        pSearch->m_counterTable[pSearch->m_pieceStack[ply - 1]][pSearch->m_moveStack[ply - 1].To()] = mv;
+
     if (pSearch->m_killerMoves[ply][0] != mv) {
         auto tmp = pSearch->m_killerMoves[ply][0];
         pSearch->m_killerMoves[ply][0] = mv;

--- a/src/moveeval.cpp
+++ b/src/moveeval.cpp
@@ -81,6 +81,8 @@
         }
         else if (mv == killer0 || mv == killer1)
             mvlist[j].m_score = s_SortKiller;
+        else if (counterMove && mv == pSearch->m_counterTable[counterPiece][counterTo])
+            mvlist[j].m_score = s_SortCounter;
         else {
             mvlist[j].m_score = pSearch->m_history[side][mv.From()][mv.To()];
 

--- a/src/moveeval.h
+++ b/src/moveeval.h
@@ -43,6 +43,7 @@ private:
     static constexpr int s_SortHash       = 7000000;
     static constexpr int s_SortCapture    = 6000000;
     static constexpr int s_SortKiller     = 5000000;
+    static constexpr int s_SortCounter    = 4000000;
     static constexpr int s_SortBadCapture = 1000000;
 };
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -671,9 +671,12 @@ void Search::clearHistory()
 void Search::clearKillers()
 {
     memset(m_killerMoves, 0, sizeof(m_killerMoves));
+    memset(m_counterTable, 0, sizeof(m_counterTable));
 
-    for (unsigned int i = 0; i < m_thc; ++i)
+    for (unsigned int i = 0; i < m_thc; ++i) {
         memset(m_threadParams[i].m_killerMoves, 0, sizeof(m_killerMoves));
+        memset(m_threadParams[i].m_counterTable, 0, sizeof(m_counterTable));
+    }
 }
 
 void Search::clearStacks()

--- a/src/search.h
+++ b/src/search.h
@@ -124,6 +124,7 @@ private:
     Move m_pvPrev[MAX_PLY][MAX_PLY];
     int m_pvSizePrev[MAX_PLY];
     Move m_killerMoves[MAX_PLY][2];
+    Move m_counterTable[14][64] = {}; // refutation move of the previous [piece][to]
     int16_t m_history[2][64][64];
     Move m_moveStack[MAX_PLY + 4];
     PIECE m_pieceStack[MAX_PLY + 4];

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.16";
+const std::string VERSION = "3.6.17";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
Passed VSTC (1.667+0.0167, 16MB):
LLR: 2.96 (-2.94, 2.94) <-1.00, 1.00>
Total: 22966 W: 5007 L: 4788 D: 13171, Elo: 3.3 +/- 2.9

Passed STC (10+0.1, 16MB):
LLR: 2.95 (-2.94, 2.94) <0.00, 2.00>
Total: 9465 W: 1152 L: 1008 D: 7305, Elo: 5.3 +/- 3.3

Passed LTC (60+0.6, 64MB):
LLR: 2.96 (-2.94, 2.94) <0.50, 2.50>
Total: 6172 W: 421 L: 332 D: 5419, Elo: 5.0 +/- 3.0

Bench: 1206045