### PR TITLE
3.6.19: minimize SEE calls

### DIFF
--- a/src/moveeval.h
+++ b/src/moveeval.h
@@ -37,6 +37,17 @@ public:
     static EVAL SEE_Exchange(Search * pSearch, FLD to, COLOR side, EVAL currScore, EVAL target, U64 occ);
     static EVAL SEE(Search * pSearch, const Move & mv);
 
+    //
+    // sortMoves already ran SEE for every non-promotion capture and encoded the result
+    // in the sort score: losing captures score s_SortBadCapture + see, winning ones stay
+    // in the capture band. Reuse that instead of a second SEE call. Not valid for the
+    // hash move, which keeps s_SortHash whatever it is.
+    //
+
+    static FORCE_INLINE bool seeCached(const Move & mv, int sortScore) { return mv.Captured() && !mv.Promotion() && sortScore != s_SortHash; }
+    static FORCE_INLINE bool cachedSeeNegative(int sortScore) { return sortScore < s_SortKiller; }
+    static FORCE_INLINE EVAL cachedSee(int sortScore) { return sortScore < s_SortKiller ? sortScore - s_SortBadCapture : 0; } // exact when losing, lower bound 0 when winning
+
     static constexpr EVAL SORT_VALUE[14] = { 0, 0, VAL_P, VAL_P, VAL_N, VAL_N, VAL_B, VAL_B, VAL_R, VAL_R, VAL_Q, VAL_Q, VAL_K, VAL_K };
 
 private:

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -410,7 +410,10 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
                 seeMargin[0] = SEENoisyMargin * depth * depth;
                 seeMargin[1] = SEEQuietMargin * depth;
 
-                if (MoveEval::SEE(this, mv) < seeMargin[quietMove])
+                const auto sortScore = mvlist[i].m_score;
+                const EVAL see = MoveEval::seeCached(mv, sortScore) ? MoveEval::cachedSee(sortScore) : MoveEval::SEE(this, mv);
+
+                if (see < seeMargin[quietMove])
                     continue;
             }
         }
@@ -621,7 +624,9 @@ EVAL Search::qSearch(EVAL alpha, EVAL beta, int ply, int depth, bool isNull/* = 
     for (size_t i = 0; i < mvSize; ++i) {
         Move mv = MoveEval::getNextBest(mvlist, i);
 
-        if (!inCheck && MoveEval::SEE(this, mv) < 0)
+        const auto sortScore = mvlist[i].m_score;
+
+        if (!inCheck && (MoveEval::seeCached(mv, sortScore) ? MoveEval::cachedSeeNegative(sortScore) : MoveEval::SEE(this, mv) < 0))
             continue;
 
         if (m_position.MakeMove(mv)) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.18";
+const std::string VERSION = "3.6.19";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ igel ·>
005-see-cache-reuse

Passed VSTC (2.5+0.025, 8MB):
LLR: 2.96 (-2.94, 2.94) <-1.00, 1.00>
Total: 24100 W: 4746 L: 4548 D: 14806, Elo: 2.9 +/- 2.7

Bench: 1206045
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^