### PR TITLE
3.6.20: reduce tt captures

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -351,6 +351,8 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
     U8 type = HASH_ALPHA;
     Move bestMove = hashMove;
 
+    const auto ttCapture = hashMove && hashMove.Captured();
+
     MoveList& mvlist = m_lists[ply];
     if (inCheck)
         GenMovesInCheck(m_position, mvlist);
@@ -466,7 +468,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
             if (depth >= 3 && quietMove && legalMoves > 1 + 2 * rootNode) {
                 reduction = m_logLMRTable[std::min(depth, 63)][std::min(legalMoves, 63)];
 
-                reduction += cutNode;
+                reduction += cutNode + ttCapture;
 
                 if (onPV)
                     reduction -= 2;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.19";
+const std::string VERSION = "3.6.20";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ igel ·>
002-ttcapture-lmr-reduction

Passed VSTC (2.5+0.025, 8MB):
LLR: 2.95 (-2.94, 2.94) <-1.00, 1.00>
Total: 21920 W: 4115 L: 3927 D: 13878, Elo: 3.0 +/- 2.8

Passed STC (10+0.1, 16MB):
LLR: 2.95 (-2.94, 2.94) <0.00, 2.00>
Total: 42291 W: 5035 L: 4794 D: 32462, Elo: 2.0 +/- 1.6

Passed LTC (60+0.6, 64MB):
LLR: 2.96 (-2.94, 2.94) <0.50, 2.50>
Total: 11528 W: 861 L: 740 D: 9927, Elo: 3.6 +/- 2.4

Bench: 1194723
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^