### PR TITLE
3.6.27: detect bmi2 in basic makefile

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -21,7 +21,8 @@ NNFLAGS  = -DEVALFILE=\"$(EVALFILE)\"
 LIBS   = -std=c++17 -mpopcnt -pthread -lstdc++ -lm
 WARN   = -Wall
 OPTIM  = -O3 -march=native -flto=auto -funroll-loops
-DEFS   = -DNDEBUG -D_BTYPE=0 -DSYZYGY_SUPPORT=TRUE
+BTYPE  = 0
+DEFS   = -DNDEBUG -D_BTYPE=$(BTYPE) -DSYZYGY_SUPPORT=TRUE
 
 ifneq ($(findstring __AVX2__, $(GCCDEFINES)),)
     LIBS += -mavx2
@@ -41,6 +42,15 @@ endif
 ifneq ($(findstring __AVXVNNI__, $(GCCDEFINES)),)
     LIBS += -mavxvnni
     DEFS += -DUSE_AVXVNNI=1
+endif
+
+ifneq ($(findstring __BMI2__, $(GCCDEFINES)),)
+ifeq ($(findstring __znver1, $(GCCDEFINES)),)
+ifeq ($(findstring __znver2, $(GCCDEFINES)),)
+    BTYPE = 1
+    LIBS += -mbmi2
+endif
+endif
 endif
 
 CFLAGS = $(WARN) $(LIBS) $(OPTIM) $(NNFLAGS)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.26";
+const std::string VERSION = "3.6.27";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
Elo   | 2.26 +- 1.90 (95%)
SPRT  | 2.5+0.03s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 1.00]
Games | N: 49082 W: 13920 L: 13601 D: 21561
Penta | [867, 5689, 11191, 5846, 948]
https://chess.grantnet.us/test/40727/

bench: 3905167