### PR TITLE
3.6.28: ordered moves during probcut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -317,13 +317,15 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
             auto captureMovesSize = captureMoves.Size();
             for (size_t i = 0; i < captureMovesSize; ++i) {
-                if (skipMove == captureMoves[i].m_mv)
+                const Move captureMove = MoveEval::getNextBest(captureMoves, i);
+
+                if (skipMove == captureMove)
                     continue;
 
-                if (MoveEval::SEE(this, captureMoves[i].m_mv) < betaCut - staticEval)
+                if (MoveEval::SEE(this, captureMove) < betaCut - staticEval)
                     continue;
 
-                if (m_position.MakeMove(captureMoves[i].m_mv)) {
+                if (m_position.MakeMove(captureMove)) {
 
                     auto score = -qSearch(-betaCut, -betaCut + 1, ply, 0);
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.27";
+const std::string VERSION = "3.6.28";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
Elo   | 1.58 +- 1.22 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.00]
Games | N: 94146 W: 23351 L: 22922 D: 47873
Penta | [631, 11343, 22748, 11668, 683]
https://chess.grantnet.us/test/40735/

Elo   | 2.33 +- 1.44 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.50, 2.50]
Games | N: 57450 W: 13670 L: 13284 D: 30496
Penta | [111, 6758, 14617, 7112, 127]
https://chess.grantnet.us/test/40736/

bench: 3743712