### PR TITLE
3.6.29: use tt for skipmove positions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -135,7 +135,12 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
     if (depth <= 0 && m_level > MEDIUM_LEVEL)
         return qSearch(alpha, beta, ply, 0, isNull);
 
-    const U64 hash = m_position.Hash();
+    //
+    //  an excluded-move search asks a different question about the same position, so it gets its own key
+    //
+
+    const U64 skipKey = skipMove ? 0x9E3779B97F4A7C15ull * static_cast<U64>(static_cast<U32>(skipMove)) : 0;
+    const U64 hash = m_position.Hash() ^ skipKey;
     TTable::instance().prefetchEntry(hash);
 
     ++m_nodes;
@@ -170,7 +175,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
     EVAL ttScore = 0;
     auto onPV    = (beta - alpha > 1);
-    auto ttHit   = !skipMove && ProbeHash(hEntry, hash);
+    auto ttHit   = ProbeHash(hEntry, hash);
 
     if (ttHit) {
         ttScore = hEntry.m_data.score;
@@ -553,8 +558,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
     assert((m_position.Fifty() >= 100) == false); // we must cut off at the begining of a node search for draws
 
-    if (!skipMove)
-        TTable::instance().record(bestMove, bestScore, depth, ply, type, hash);
+    TTable::instance().record(bestMove, bestScore, depth, ply, type, hash);
 
     return bestScore;
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.28";
+const std::string VERSION = "3.6.29";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
Elo   | 1.42 +- 1.12 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 2.00]
Games | N: 115192 W: 29000 L: 28530 D: 57662
Penta | [913, 13888, 27560, 14286, 949]
https://chess.grantnet.us/test/40737/

Elo   | 2.21 +- 1.38 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.50, 2.50]
Games | N: 62200 W: 14752 L: 14356 D: 33092
Penta | [120, 7265, 15933, 7663, 119]
https://chess.grantnet.us/test/40740/

bench: 3688616