### PR TITLE
3.6.29: apply incheck futility guard

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -413,7 +413,8 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
                 auto futilityMargin = staticEval + 90 * depth;
 
-                if (futilityMargin <= alpha
+                if (!inCheck
+                    && futilityMargin <= alpha
                     && depth <= 8
                     && history.history + history.cmhistory + history.fmhistory < m_fpHistoryLimit[improving])
                     skipQuiets = true;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.29";
+const std::string VERSION = "3.6.30";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
Elo   | 20.90 +- 5.72 (95%)
SPRT  | 2.5+0.03s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 2.00]
Games | N: 5710 W: 1781 L: 1438 D: 2491
Penta | [91, 575, 1229, 820, 140]
https://chess.grantnet.us/test/40751/

Elo   | 4.83 +- 2.47 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 2.00]
Games | N: 23402 W: 6026 L: 5701 D: 11675
Penta | [173, 2733, 5595, 2996, 204]
https://chess.grantnet.us/test/40745/

Elo   | 1.63 +- 2.37 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 21074 W: 4949 L: 4850 D: 11275
Penta | [38, 2496, 5362, 2611, 30]
https://chess.grantnet.us/test/40749/

bench: 3568797