### PR TITLE
3.6.33: singular search ply coherence

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -360,7 +360,8 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
     const auto ttCapture = hashMove && hashMove.Captured();
 
-    MoveList& mvlist = m_lists[ply];
+    auto & mvlist = ply == m_singularPly ? m_singularLists[ply] : m_lists[ply];
+
     if (inCheck)
         GenMovesInCheck(m_position, mvlist);
     else
@@ -450,7 +451,10 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
         if (depth >= 8 && !skipMove && hashMove == mv && !rootNode && !isCheckMateScore(hEntry.m_data.score) && hEntry.m_data.type == HASH_BETA && hEntry.m_data.depth >= depth - 3) {
             auto betaCut = hEntry.m_data.score - depth;
-            auto score = abSearch(betaCut - 1, betaCut, depth / 2, ply + 1, false, false, cutNode, mv);
+            const auto savedSingularPly = m_singularPly;
+            m_singularPly = ply;
+            auto score = abSearch(betaCut - 1, betaCut, depth / 2, ply, false, false, cutNode, mv);
+            m_singularPly = savedSingularPly;
 
             if (score < betaCut) {
                 extension = 1;
@@ -632,7 +636,8 @@ EVAL Search::qSearch(EVAL alpha, EVAL beta, int ply, int depth, bool isNull/* = 
             alpha = bestScore;
     }
 
-    MoveList& mvlist = m_lists[ply];
+    auto & mvlist = ply == m_singularPly ? m_singularLists[ply] : m_lists[ply];
+
     if (inCheck)
         GenMovesInCheck(m_position, mvlist);
     else

--- a/src/search.h
+++ b/src/search.h
@@ -119,6 +119,8 @@ private:
     int m_syzygyDepth;
     int m_selDepth;
     MoveList m_lists[MAX_PLY];
+    MoveList m_singularLists[MAX_PLY];  // excluded search runs at the parent's ply
+    int m_singularPly = -1;             // every frame at that ply uses the parallel list
     Move m_pv[MAX_PLY][MAX_PLY];
     int m_pvSize[MAX_PLY];
     Move m_pvPrev[MAX_PLY][MAX_PLY];

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.32";
+const std::string VERSION = "3.6.33";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
Elo   | 1.31 +- 1.04 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 2.00]
Games | N: 130300 W: 32600 L: 32110 D: 65590
Penta | [914, 15801, 31292, 16167, 976]
https://chess.grantnet.us/test/40760/

Elo   | 3.46 +- 1.96 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 2.00]
Games | N: 31258 W: 7418 L: 7107 D: 16733
Penta | [55, 3638, 7964, 3885, 87]
https://chess.grantnet.us/test/40766/

bench: 3709046