### PR TITLE
3.6.35: improve TT replace strategy

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -34,10 +34,6 @@
 #include <map>
 #include <utility>
 
-const U8 HASH_ALPHA = 0;
-const U8 HASH_EXACT = 1;
-const U8 HASH_BETA = 2;
-
 /*static */constexpr int Search::m_lmpDepth;
 /*static */constexpr int Search::m_lmpPruningTable[2][9];
 /*static */constexpr int Search::m_cmpDepth[2];

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -55,7 +55,20 @@ void TTable::record(Move mv, EVAL score, I8 depth, int ply, U8 type, U64 hash0)
 
     for (auto i = 0; i < 4; ++i) {
         // empty bucket or a matched hash
-        if ((!cluster.entry[i].m_key) || ((cluster.entry[i].m_key ^ cluster.entry[i].m_data.raw) == hash0)) {
+        if (!cluster.entry[i].m_key) {
+            replaceEntry = &cluster.entry[i];
+            break;
+        }
+
+        if ((cluster.entry[i].m_key ^ cluster.entry[i].m_data.raw) == hash0) {
+
+            //
+            //  a key match from this generation is kept unless the new result is exact or nearly as deep
+            //
+
+            if (type != HASH_EXACT && cluster.entry[i].m_data.age == curAge && depth + 4 < cluster.entry[i].m_data.depth)
+                return;
+
             replaceEntry = &cluster.entry[i];
             break;
         }

--- a/src/tt.h
+++ b/src/tt.h
@@ -22,6 +22,10 @@
 
 #include "position.h"
 
+const U8 HASH_ALPHA = 0;
+const U8 HASH_EXACT = 1;
+const U8 HASH_BETA  = 2;
+
 class TEntry
 {
 public:

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.33";
+const std::string VERSION = "3.6.34";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
Elo   | 3.03 +- 1.87 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 2.00]
Games | N: 39844 W: 10115 L: 9768 D: 19961
Penta | [290, 4668, 9673, 4987, 304]
https://chess.grantnet.us/test/40778/

Elo   | 5.48 +- 2.56 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.00]
Games | N: 18256 W: 4405 L: 4117 D: 9734
Penta | [33, 2089, 4597, 2375, 34]
https://chess.grantnet.us/test/40780/

bench: 3838324