### PR TITLE
3.6.35: update piece stack for null move prunning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -296,9 +296,18 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
         if (!isNull && depth >= 3 && bestScore >= beta && (!ttHit || !(hEntry.m_data.type == HASH_BETA) || ttScore >= beta) && m_position.NonPawnMaterial()) {
             int R = 5 + depth / 6 + std::min(3, (bestScore - beta) / 100);
 
+            const auto savedMove  = m_moveStack[ply];
+            const auto savedPiece = m_pieceStack[ply];
+
+            m_moveStack[ply]  = Move{};
+            m_pieceStack[ply] = 0;
+
             m_position.MakeNullMove();
             EVAL nullScore = -abSearch(-beta, -beta + 1, depth - R, ply + 1, true, false, !cutNode);
             m_position.UnmakeNullMove();
+
+            m_moveStack[ply]  = savedMove;
+            m_pieceStack[ply] = savedPiece;
 
             if (nullScore >= beta)
                 return isCheckMateScore(nullScore) ? beta : nullScore;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.34";
+const std::string VERSION = "3.6.35";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
Elo   | 2.31 +- 1.59 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 2.00]
Games | N: 56094 W: 14147 L: 13774 D: 28173
Penta | [408, 6688, 13503, 7019, 429]
https://chess.grantnet.us/test/40787/

Elo   | 6.09 +- 2.69 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 2.00]
Games | N: 16098 W: 3903 L: 3621 D: 8574
Penta | [30, 1766, 4178, 2042, 33]
https://chess.grantnet.us/test/40788/

bench: 3909768