### PR TITLE
3.6.36: use fifty move guard on tt in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -605,7 +605,7 @@ EVAL Search::qSearch(EVAL alpha, EVAL beta, int ply, int depth, bool isNull/* = 
         if (hEntry.m_data.depth >= tteDepth) {
             auto onPV = (beta - alpha > 1);
 
-            if (!onPV && (hEntry.m_data.type == HASH_EXACT
+            if (!onPV && (m_position.Fifty() < 90) && (hEntry.m_data.type == HASH_EXACT
                 || (hEntry.m_data.type == HASH_BETA && ttScore >= beta)
                 || (hEntry.m_data.type == HASH_ALPHA && ttScore <= alpha)))
                 return ttScore;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.35";
+const std::string VERSION = "3.6.36";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
Elo   | 0.10 +- 0.93 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 3.05 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 72032 W: 13107 L: 13086 D: 45839
Penta | [23, 4686, 26579, 4703, 25]
https://chess.grantnet.us/test/40812/

bench: 3909768