### PR TITLE
3.6.37: fix mate score for probcut

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -319,7 +319,7 @@ EVAL Search::abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bo
 
         auto betaCut = beta + 100;
 
-        if (depth >= 5 && !(ttHit && hEntry.m_data.depth >= (depth - 4) && hEntry.m_data.score < betaCut)) {
+        if (depth >= 5 && !(ttHit && hEntry.m_data.depth >= (depth - 4) && ttScore < betaCut)) {
             MoveList captureMoves;
 
             GenCapturesAndPromotions(m_position, captureMoves);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.36";
+const std::string VERSION = "3.6.37";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
Elo   | 1.34 +- 2.30 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 25730 W: 6470 L: 6371 D: 12889
Penta | [197, 2958, 6431, 3107, 172]
https://chess.grantnet.us/test/40815/

bench: 3909768