### PR TITLE
3.6.38: fix history overflow

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -65,7 +65,7 @@
 
         if (followMove) {
             int fentry = pSearch->m_followTable[1][followPiece][followTo][mv.Piece()][to];
-            fentry += s_historyMultiplier * delta - fentry * abs(bonus) / s_historyDivisor;
+            fentry += s_historyMultiplier * delta - fentry * abs(delta) / s_historyDivisor;
             pSearch->m_followTable[1][followPiece][followTo][piece][to] = static_cast<int16_t>(fentry);
         }
     }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.37";
+const std::string VERSION = "3.6.38";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
Elo   | 0.04 +- 2.12 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 1.05 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 29756 W: 7333 L: 7330 D: 15093
Penta | [181, 3552, 7419, 3535, 191]
https://chess.grantnet.us/test/40819/

Elo   | 1.95 +- 2.47 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 3.06 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 18668 W: 4402 L: 4297 D: 9969
Penta | [38, 2099, 4947, 2220, 30]
https://chess.grantnet.us/test/40817/

bench: 3909768