### PR TITLE
3.6.39: fix draw detection

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -121,6 +121,7 @@ void Position::Clear()
     m_ply = 0;
     m_side = WHITE;
     m_undoSize = 0;
+    m_searchRoot = 0;
 }
 
 std::string Position::FEN() const
@@ -749,6 +750,52 @@ int Position::Repetitions() const
             break;
     }
     return r;
+}
+
+bool Position::isDrawByRepetition() const
+{
+    //
+    //  A position needs four reversible plies behind it before it can possibly repeat
+    //
+
+    if (m_fifty < 4)
+        return false;
+
+    const auto hash0 = Hash();
+    int        seen  = 0;
+
+    for (int i = m_undoSize - 1; i >= 0; --i) {
+
+        if (m_undos[i].m_hash == hash0) {
+
+            //
+            //  A position met again inside the search tree is scored as a draw on the first repetition
+            //
+
+            if (i > m_searchRoot)
+                return true;
+
+            //
+            //  A position that occurred at the root or earlier in the actual game only becomes a draw once it is about to occur for the third time
+            //
+
+            if (++seen >= 2)
+                return true;
+        }
+
+        auto mv = m_undos[i].m_mv;
+
+        if (mv == 0)
+            break;
+
+        if (mv.Captured())
+            break;
+
+        if (mv.Piece() <= PB)
+            break;
+    }
+
+    return false;
 }
 
 bool Position::SetFEN(const std::string& fen)

--- a/src/position.h
+++ b/src/position.h
@@ -164,6 +164,8 @@ public:
     int    Ply() const { return m_ply; }
     void   Print() const;
     int    Repetitions() const;
+    bool   isDrawByRepetition() const;
+    void   setSearchRoot() { m_searchRoot = m_undoSize; }
     bool   SetFEN(const std::string& fen);
     void   SetInitial();
     COLOR  Side() const { return m_side; }
@@ -220,6 +222,7 @@ private:
     enum { MAX_UNDO = 2048 };
     Undo m_undos[MAX_UNDO];
     int m_undoSize;
+    int m_searchRoot;
     bool m_initialPosition;
 #if !defined(PURE_HCE)
     EvalList evalList;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -111,7 +111,7 @@ bool Search::checkLimits()
 
 bool Search::isDraw()
 {
-    if ((m_position.Repetitions() >= 2) || (m_position.Fifty() >= 100))
+    if (m_position.isDrawByRepetition() || (m_position.Fifty() >= 100))
         return true;
 
     if (!m_position.Count(PW) && !m_position.Count(PB)) {
@@ -1023,6 +1023,8 @@ uint64_t Search::startSearch(Time time, int depth, bool ponderSearch, bool bench
     m_tbHits = 0;
     m_limitCheck = 1023;
 
+    m_position.setSearchRoot();
+
     if (!m_ponderHit) {
         m_t0 = GetProcTime();
         m_time = time;
@@ -1137,13 +1139,10 @@ uint64_t Search::startSearch(Time time, int depth, bool ponderSearch, bool bench
             if (m_pvSize[0] && m_pv[0][0]) {
                 m_best = m_pv[0][0];
 
-                if (m_pvSize[0] > 1 && m_pv[0][1]) {
-                    m_ponder = m_pv[0][1];
-                    memcpy(m_pvPrev, m_pv, sizeof(m_pv));
-                    memcpy(m_pvSizePrev, m_pvSize, sizeof(m_pvSize));
-                }
-                else
-                    m_ponder = 0;
+                memcpy(m_pvPrev, m_pv, sizeof(m_pv));
+                memcpy(m_pvSizePrev, m_pvSize, sizeof(m_pvSize));
+
+                m_ponder = (m_pvSize[0] > 1 && m_pv[0][1]) ? m_pv[0][1] : Move{};
             }
 
             aspiration += 2 + aspiration / 2;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.38";
+const std::string VERSION = "3.6.39";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
Elo   | 2.63 +- 2.42 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 11210 W: 2172 L: 2087 D: 6951
Penta | [2, 742, 4035, 821, 5]
https://chess.grantnet.us/test/40820/

Elo   | 0.55 +- 1.19 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 32586 W: 5991 L: 5939 D: 20656
Penta | [1, 1601, 13037, 1653, 1]
https://chess.grantnet.us/test/40821/

bench: 3805527