### PR TITLE
Release Igel 3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ As of late 2020 Igel adoped NNUE and uses own NNUE implementation and own networ
 
 In January 2023 last bits of HCE code were removed from Igel and the evaluation is fully based on NNUE as of Igel 3.4.0.
 
+### Evaluation
+
+- NNUE
+  - Horizontally Mirrored 32 King Buckets
+  - HalfKAv2_hm + FullThreats
+  - 2x(22528 + 60144 -> 1024) -> 16 -> 32 -> 1
+  - 8 Output Buckets
+  - 8 PSQT Buckets
+  - Using Igel evaluation and search data
+- Igel HCE (-DPURE_HCE)
+
 ### Acknowledgements
 
 I would like to thank the authors and the community involved in the creation of the open source projects listed below. Their work influences development of Igel, and without them, this project wouldn't exist. Special thanks to Andrew Grant and Bojun Guo for supporting Igel development on OpenBench.
@@ -43,7 +54,7 @@ I would like to thank the authors and the community involved in the creation of 
 
 ### Compiling
 
-Official compilation method involves cmake and gcc/Visual Studio 2019 and assumes a modern CPU with AVX2 support (most of the computers produced in last 9 years).
+Official compilation method involves cmake and gcc/Visual Studio 2022 and assumes a modern CPU with AVX2 support (most of the computers produced in last 9 years).
 
 Using cmake/Visual Studio 2022:
 
@@ -60,7 +71,7 @@ Using cmake/gcc:
 git clone https://github.com/vshcherbyna/igel.git ./igel
 cd igel
 git submodule update --init --recursive
-wget https://github.com/vshcherbyna/igel/releases/download/3.5.0/c049c117 -O ./network_file
+wget https://github.com/vshcherbyna/igel/releases/download/0.8/020217C0.network -O ./network_file
 cmake -DEVALFILE=network_file -DUSE_AVX2=1 -D_BTYPE=1 -DSYZYGY_SUPPORT=TRUE .
 make -j
 ```
@@ -71,20 +82,15 @@ To compile with AVX512 and VNNI support use -DUSE_VNNI=1 -DUSE_AVX512=1, for exa
 git clone https://github.com/vshcherbyna/igel.git ./igel
 cd igel
 git submodule update --init --recursive
-wget https://github.com/vshcherbyna/igel/releases/download/3.5.0/c049c117 -O ./network_file
+wget https://github.com/vshcherbyna/igel/releases/download/0.8/020217C0.network -O ./network_file
 cmake -DEVALFILE=network_file -DUSE_AVX2=1 -DUSE_AVX512=1 -DUSE_VNNI=1 -D_BTYPE=1 -DSYZYGY_SUPPORT=TRUE .
 make -j
 ```
 
-On Linux you can also build with clang and full LTO. This uses the LLVM 19 toolchain - clang-19 and the lld-19 linker.
+You can also compile using MSYS2 CLANG64 on Windows:
 
 ```
-git clone https://github.com/vshcherbyna/igel.git ./igel
-cd igel
-git submodule update --init --recursive
-wget https://github.com/vshcherbyna/igel/releases/download/3.5.0/c049c117 -O ./network_file
-cmake -DCMAKE_C_COMPILER=clang-19 -DCMAKE_CXX_COMPILER=clang++-19 -DEVALFILE=network_file -DUSE_AVX2=1 -DUSE_AVX512=1 -DUSE_VNNI=1 -D_BTYPE=1 -DSYZYGY_SUPPORT=TRUE .
-make -j
+mingw32-make pgo CLANGCC=clang++ CLANGLD=lld PROFDATA=llvm-profdata
 ```
 
 Important! If you make a custom build of Igel you need to validate the bench using command:
@@ -101,4 +107,4 @@ or if you are running Linux:
 
 The 'Nodes' must match the 'BENCH :' value from the last commit message.
 
-It is also possible to compile using gcc and a traditional makefile, please consult ./src/makefile for more details.
+It is also possible to compile using gcc and a traditional makefile on Linux and Windows with MSYS2 CLANG64 , please consult ./src/makefile for more details.

--- a/history.txt
+++ b/history.txt
@@ -1,7 +1,52 @@
 Igel - open source chess engine forked from GreKo 2018.01.
 
-(c) 2018-2025 Volodymyr Shcherbyna <volodymyr@shcherbyna.com> (Igel author)
+(c) 2018-2026 Volodymyr Shcherbyna <volodymyr@shcherbyna.com> (Igel author)
 (c) 2002-2018 Vladimir Medvedev <vrm@bk.ru> (GreKo author)
+
+Igel 3.7.0
+-------------
+26.08.2026
+
+- fix draw detection
+- fix history overflow
+- fix mate score for probcut
+- use fifty move guard on tt in qsearch
+- update piece stack for null move pruning
+- improve tt replace strategy
+- fix ply coherence in singular search
+- fix undefined behavior in history
+- fix undo bug
+- apply incheck futility guard
+- use tt for skipmove positions
+- order moves during probcut
+- detect bmi2 in basic makefile
+- support vnni256
+- optimize quiets pickup
+- speed-up castling
+- store tt wdl result as a bonus
+- fix tb probing with wrong castling rights
+- reduce tt captures
+- minimize see calls
+- implement finny table
+- implement counter move table
+- track best move stability
+- use tt for null moves
+- release new standard network
+- implement evalfile parameter
+- fix tb tt bug
+- restore hce build for tcec
+- probe dtz
+- fix tt castling bit for frc
+- cache hash entry
+- speed-up inferencing code
+- implement avx512 support
+- improve voting system
+- fix gcc14 build
+- implement frc mode
+- improve speed
+- support longer games
+- optimize sort
+- penalize bad captures
 
 Igel 3.6.0
 -------------

--- a/src/bitboards.cpp
+++ b/src/bitboards.cpp
@@ -35,6 +35,7 @@
 U64 BB_SINGLE[64];
 U64 BB_DIR[64][8];
 U64 BB_BETWEEN[64][64];
+U64 BB_RAY[64][64];
 
 U64 BB_PAWN_ATTACKS[64][2];
 U64 BB_KNIGHT_ATTACKS[64];
@@ -530,7 +531,7 @@ void InitBitboards()
     for (from = 0; from < 64; ++from)
     {
         for (to = 0; to < 64; ++to)
-            BB_BETWEEN[from][to] = 0;
+            BB_BETWEEN[from][to] = BB_RAY[from][to] = 0;
 
         for (int dir = 0; dir < 8; ++dir)
         {
@@ -547,7 +548,13 @@ void InitBitboards()
             }
             BB_DIR[from][dir] = y;
         }
-        
+
+        for (int dir = 0; dir < 8; ++dir) {
+            U64 ray = BB_DIR[from][dir];
+            for (U64 b = ray; b;)
+                BB_RAY[from][PopLSB(b)] = ray;
+        }
+
         BB_BISHOP_ATTACKS[from] =
             BB_DIR[from][DIR_UR] |
             BB_DIR[from][DIR_UL] |

--- a/src/bitboards.h
+++ b/src/bitboards.h
@@ -30,6 +30,7 @@
 extern U64 BB_SINGLE[64];
 extern U64 BB_DIR[64][8];
 extern U64 BB_BETWEEN[64][64];
+extern U64 BB_RAY[64][64];
 
 extern U64 BB_PAWN_ATTACKS[64][2];
 extern U64 BB_KNIGHT_ATTACKS[64];

--- a/src/makefile
+++ b/src/makefile
@@ -2,17 +2,30 @@
 # This makefile is used to compile Igel for OpenBench and TCEC
 #
 
-CC  = g++
-EXE = igel
-SRC = *.cpp fathom/tbprobe.cpp
+#
+# Toolchain. CC builds the "basic" target; the CLANG* names are the LLVM
+# programs the pgo targets drive. Override any of them on the command line
+# when your toolchain spells them differently - an MSYS2 clang64 install,
+# for instance, ships them unversioned:
+#
+#     make pgo CLANGCC=clang++ CLANGLD=lld PROFDATA=llvm-profdata
+#
+
+CC       = g++
+CLANGCC  = clang++-19
+CLANGLD  = lld-19
+PROFDATA = llvm-profdata-19
+
+EXE      = igel
+SRC      = *.cpp fathom/tbprobe.cpp
 
 #
 # NNUE network: embedded via INCBIN at compile time, and fetched by the
 # $(EVALFILE) rule below if it is missing. Change these to switch networks.
 #
 
-EVALFILE    = weights/c049c117
-NETWORK_URL = https://github.com/vshcherbyna/igel/releases/download/3.5.0/c049c117
+EVALFILE    = weights/020217C0.network
+NETWORK_URL = https://github.com/vshcherbyna/igel/releases/download/0.8/020217C0.network
 
 GCCDEFINES = $(shell echo | $(CC) -m64 -march=native -E -dM -)
 
@@ -53,17 +66,18 @@ endif
 endif
 endif
 
+ifneq ($(findstring __MINGW32__, $(GCCDEFINES)),)
+    LIBS += -static
+endif
+
 CFLAGS = $(WARN) $(LIBS) $(OPTIM) $(NNFLAGS)
 
 #
 # Clang full-LTO + PGO build settings (used by the pgo targets below).
-# Clang rejects gcc's -flto=auto and links LTO through lld. Override
-# CLANGCC / CLANGLD / PROFDATA if your toolchain uses unversioned names.
+# Clang rejects gcc's -flto=auto and links LTO through lld. The program
+# names themselves are declared at the top of this file.
 #
 
-CLANGCC    = clang++-19
-CLANGLD    = lld-19
-PROFDATA   = llvm-profdata-19
 CLANGOPTIM = -O3 -march=native -flto -fuse-ld=$(CLANGLD) -funroll-loops
 CLANGFLAGS = $(WARN) $(LIBS) $(CLANGOPTIM) $(NNFLAGS)
 

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -22,10 +22,20 @@
 #include "hce.h"
 #include "utils.h"
 #include <immintrin.h>
+#include <new>
+#include <cstdlib>
 #include <streambuf>
 #include <fstream>
 #include <iostream>
 #include <atomic>
+
+#if defined(__linux__) && !defined(__ANDROID__)
+#include <sys/mman.h>
+#endif
+
+#if defined(_WIN32)
+#include <malloc.h>
+#endif
 
 #if !defined(PURE_HCE)
 #include "incbin/incbin.h"
@@ -34,7 +44,7 @@
 INCBIN(EmbeddedNNUE, EVALFILE);
 #endif // _MSC_VER
 
-/*static */std::unique_ptr<Transformer> Evaluator::m_transformer;
+/*static */TransformerPtr Evaluator::m_transformer;
 /*static */std::vector<std::unique_ptr<LayeredNetwork>> Evaluator::m_networks;
 
 // bumped on every network (re)load so per-thread refresh caches drop stale columns
@@ -88,7 +98,11 @@ bool Evaluator::initEval()
     architecture.resize(size);
     stream.read(&(architecture)[0], size);
 
-    m_transformer.reset(new Transformer(stream));
+    m_transformer = makeTransformer(stream);
+
+    if (!m_transformer)
+        return false;
+
     m_networks.clear();
 
     for (auto i = 0; i < LAYERED_NETWORKS; ++i) {
@@ -157,12 +171,152 @@ int Evaluator::NnueEvaluate(Position & pos) {
     return accumulator.score;
 }
 
+//
+// Allocate the transformer on huge pages
+//
+
+static constexpr std::size_t HugePage = 2 * 1024 * 1024;
+
+TransformerPtr makeTransformer(std::istream & s) {
+
+    const std::size_t bytes = (sizeof(Transformer) + HugePage - 1) / HugePage * HugePage;
+
+#if defined(_WIN32)
+    void * raw = _aligned_malloc(bytes, HugePage);
+#else
+    void * raw = std::aligned_alloc(HugePage, bytes);
+#endif
+
+    if (!raw)
+        return TransformerPtr();
+
+#if defined(__linux__) && !defined(__ANDROID__)
+    // same idea as the transposition table, see TTable::setHashSize
+    madvise(raw, bytes, MADV_HUGEPAGE);
+#endif
+
+    return TransformerPtr(new (raw) Transformer(s));
+}
+
+void TransformerDeleter::operator()(Transformer * t) const noexcept {
+
+    if (!t)
+        return;
+
+    t->~Transformer();
+
+#if defined(_WIN32)
+    _aligned_free(t);
+#else
+    std::free(t);
+#endif
+}
+
+static void readStrided(std::istream & s, std::int8_t * out, std::size_t rows, std::size_t width, std::size_t stride) {
+
+    for (std::size_t r = 0; r < rows; ++r)
+        s.read(reinterpret_cast<char*>(out + r * stride), width);
+}
+
 Transformer::Transformer(std::istream & s) {
     std::uint32_t header;
     s.read(reinterpret_cast<char*>(&header), sizeof(header));
     s.read(reinterpret_cast<char*>(biases), sizeof(biases));
-    s.read(reinterpret_cast<char*>(weights), sizeof(weights));
-    s.read(reinterpret_cast<char*>(psqts), sizeof(psqts));
+
+    if (header == ThreatHeader) {
+        readStrided(s, threatBlock, ThreatDimensions, HalfDimensions, ThreatStride);
+        s.read(reinterpret_cast<char*>(weights), sizeof(weights));
+        readStrided(s, threatBlock + ThreatPsqtOffset, ThreatDimensions, PSQT_BUCKETS * sizeof(std::int32_t), ThreatStride);
+        s.read(reinterpret_cast<char*>(psqts), sizeof(psqts));
+    }
+    else {
+        s.read(reinterpret_cast<char*>(weights), sizeof(weights));
+        s.read(reinterpret_cast<char*>(psqts), sizeof(psqts));
+
+        std::memset(threatBlock, 0, sizeof(threatBlock));
+    }
+}
+
+static const ThreatList EmptyThreats{};
+
+static inline void applyThreats(const Transformer & t, std::int16_t * accumulation, std::int32_t * psqt, const ThreatList & removed, const ThreatList & added) {
+
+    if (!removed.size() && !added.size())
+        return;
+
+#if defined(USE_AVX512)
+    using acc_vec_t = __m512i;
+    using col_vec_t = __m256i;
+
+    auto vadd16  = [](acc_vec_t a, acc_vec_t b) { return _mm512_add_epi16(a, b); };
+    auto vsub16  = [](acc_vec_t a, acc_vec_t b) { return _mm512_sub_epi16(a, b); };
+    auto vwiden8 = [](const col_vec_t * c) { return _mm512_cvtepi8_epi16(_mm256_load_si256(c)); };
+#elif defined(USE_AVX2)
+    using acc_vec_t = __m256i;
+    using col_vec_t = __m128i;
+
+    auto vadd16  = [](acc_vec_t a, acc_vec_t b) { return _mm256_add_epi16(a, b); };
+    auto vsub16  = [](acc_vec_t a, acc_vec_t b) { return _mm256_sub_epi16(a, b); };
+    auto vwiden8 = [](const col_vec_t * c) { return _mm256_cvtepi8_epi16(_mm_load_si128(c)); };
+#endif
+
+#if defined(USE_AVX2)
+#if defined(USE_AVX512)
+    constexpr std::uint32_t ThreatRegs = NUM_REGS;
+#else
+    constexpr std::uint32_t ThreatRegs = NUM_REGS / 2;
+#endif
+
+    constexpr std::uint32_t TileHeight = ThreatRegs * sizeof(acc_vec_t) / sizeof(std::int16_t);
+    constexpr std::uint32_t NumTiles   = Transformer::HalfDimensions / TileHeight;
+
+    static_assert(Transformer::HalfDimensions % TileHeight == 0);
+
+    const std::int8_t * columns[2 * ThreatList::MAX_LENGTH];
+    const size_t        columnCount = removed.size() + added.size();
+
+    for (size_t i = 0; i < removed.size(); ++i)
+        columns[i] = t.threatWeights(removed[i]);
+
+    for (size_t i = 0; i < added.size(); ++i)
+        columns[removed.size() + i] = t.threatWeights(added[i]);
+
+    for (std::uint32_t tile = 0; tile < NumTiles; ++tile) {
+
+        const std::uint32_t offset = tile * TileHeight;
+        auto accTile = reinterpret_cast<acc_vec_t*>(accumulation + offset);
+
+        acc_vec_t acc[ThreatRegs];
+
+        for (std::uint32_t k = 0; k < ThreatRegs; ++k)
+            acc[k] = accTile[k];
+
+        for (size_t i = 0; i < removed.size(); ++i) {
+            auto column = reinterpret_cast<const col_vec_t*>(columns[i] + offset);
+            for (std::uint32_t k = 0; k < ThreatRegs; ++k)
+                acc[k] = vsub16(acc[k], vwiden8(&column[k]));
+        }
+
+        for (size_t i = removed.size(); i < columnCount; ++i) {
+            auto column = reinterpret_cast<const col_vec_t*>(columns[i] + offset);
+            for (std::uint32_t k = 0; k < ThreatRegs; ++k)
+                acc[k] = vadd16(acc[k], vwiden8(&column[k]));
+        }
+
+        for (std::uint32_t k = 0; k < ThreatRegs; ++k)
+            accTile[k] = acc[k];
+    }
+
+    __m256i psqtAcc = _mm256_load_si256(reinterpret_cast<const __m256i*>(psqt));
+
+    for (size_t i = 0; i < removed.size(); ++i)
+        psqtAcc = _mm256_sub_epi32(psqtAcc, _mm256_load_si256(reinterpret_cast<const __m256i*>(t.threatPsqts(removed[i]))));
+
+    for (size_t i = 0; i < added.size(); ++i)
+        psqtAcc = _mm256_add_epi32(psqtAcc, _mm256_load_si256(reinterpret_cast<const __m256i*>(t.threatPsqts(added[i]))));
+
+    _mm256_store_si256(reinterpret_cast<__m256i*>(psqt), psqtAcc);
+#endif
 }
 
 inline __m256i vec_msb_pack_16(__m256i a, __m256i b) {
@@ -436,6 +590,10 @@ static void refreshPerspective(Transformer & t, Position & pos, COLOR c) {
     for (std::size_t k = 0; k < PSQT_BUCKETS; ++k)
         accumulator.psqtAccumulation[c][k] = entry.psqt[k];
 #endif
+
+    ThreatList active;
+    getActiveThreatIndexes(pos, c, active);
+    applyThreats(t, accumulator.accumulation[c], accumulator.psqtAccumulation[c], EmptyThreats, active);
 }
 
 inline void Transformer::incremental(Position & pos, const Accumulator * baseAcc) {
@@ -569,6 +727,9 @@ inline void Transformer::incremental(Position & pos, const Accumulator * baseAcc
 #if defined(USE_AVX2)
             }
 #endif
+            ThreatList thrRemoved, thrAdded;
+            getChangedThreatIndexes(c, pos.King(c), pos.state()->dirtyThreats, thrRemoved, thrAdded);
+            applyThreats(*this, accumulator.accumulation[c], accumulator.psqtAccumulation[c], thrRemoved, thrAdded);
         }
     }
 }

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -26,6 +26,7 @@
 #include <immintrin.h>
 
 #include "types.h"
+#include "threats.h"
 
 class Position;
 struct Accumulator;
@@ -60,14 +61,39 @@ public:
     inline void incremental(Position & pos, const Accumulator * baseAcc = nullptr);
 
 public:
-    static constexpr int HalfDimensions  = 1024;
-    static constexpr int InputDimensions = 22528;
+    static constexpr int HalfDimensions   = 1024;
+    static constexpr int InputDimensions  = 22528;
+    static constexpr int ThreatDimensions = THREAT_DIMENSIONS;
+
+    static constexpr std::uint32_t HalfKaHashValue = 0x7f234cb8u;
+    static constexpr std::uint32_t ThreatHeader    = (((THREAT_HASH_VALUE << 1) | (THREAT_HASH_VALUE >> 31)) ^ HalfKaHashValue) ^ (HalfDimensions * 2);
 
 public:
     alignas(CACHE_LINE) int16_t biases[HalfDimensions];
     alignas(CACHE_LINE) int16_t weights[HalfDimensions * InputDimensions];
     alignas(CACHE_LINE) int32_t psqts[InputDimensions  * PSQT_BUCKETS];
+
+    static constexpr int ThreatPsqtOffset = HalfDimensions;
+    static constexpr int ThreatStride     = (HalfDimensions + PSQT_BUCKETS * int(sizeof(int32_t)) + CACHE_LINE - 1) / CACHE_LINE * CACHE_LINE;
+
+    alignas(CACHE_LINE) int8_t threatBlock[std::size_t(ThreatDimensions) * ThreatStride];
+
+    const int8_t * threatWeights(std::size_t index) const {
+        return &threatBlock[index * ThreatStride];
+    }
+
+    const int32_t * threatPsqts(std::size_t index) const {
+        return reinterpret_cast<const int32_t*>(&threatBlock[index * ThreatStride + ThreatPsqtOffset]);
+    }
 };
+
+struct TransformerDeleter {
+    void operator()(Transformer * t) const noexcept;
+};
+
+using TransformerPtr = std::unique_ptr<Transformer, TransformerDeleter>;
+
+TransformerPtr makeTransformer(std::istream & s);
 
 template <std::int32_t WeightScaleBits, std::int32_t InputDimensions> class ClippedReLU {
 
@@ -114,7 +140,7 @@ private:
     int NnueEvaluate(Position & pos);
 
 private:
-    static std::unique_ptr<Transformer> m_transformer;
+    static TransformerPtr m_transformer;
     static std::vector<std::unique_ptr<LayeredNetwork>> m_networks;
 
 public:

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -36,10 +36,6 @@ U64 Position::s_hashCastlings[256];
 U64 Position::s_hashEP[256];
 
 const int Position::s_matIndexDelta[14] = { 0, 0, 0, 0, 3, 3, 3, 3, 5, 5, 10, 10, 0, 0 };
-#if !defined(PURE_HCE)
-static Piece PieceAdapter[] = { NO_PIECE, NO_PIECE, W_PAWN, B_PAWN, W_KNIGHT, B_KNIGHT, W_BISHOP, B_BISHOP, W_ROOK, B_ROOK, W_QUEEN, B_QUEEN, W_KING, B_KING };
-#endif
-
 bool Position::CanCastle(COLOR side, U8 flank) const
 {
     if (InCheck())
@@ -212,8 +208,6 @@ U64 Position::GetAttacks(FLD to, COLOR side, U64 occ) const
     return att;
 }
 
-
-
 void Position::InitHashNumbers()
 {
     RandSeed(30147);
@@ -285,6 +279,11 @@ bool Position::MakeMove(Move mv)
     PieceId dp1 = PIECE_ID_NONE;
     auto & dp = m_state->dirtyPiece;
     dp.dirty_num = 1;
+
+    auto * const threats = &m_state->dirtyThreats;
+    threats->clear();
+#else
+    DirtyThreats * const threats = nullptr;
 #endif
 
     FLD from = mv.From();
@@ -309,9 +308,9 @@ bool Position::MakeMove(Move mv)
 #endif
         m_fifty = 0;
         if (to == m_ep)
-            Remove(to + 8 - 16 * side);
+            Remove(to + 8 - 16 * side, threats);
         else
-            Remove(to);
+            Remove(to, threats);
 
 #if !defined(PURE_HCE)
         dp.dirty_num = 2; // 2 pieces moved
@@ -341,7 +340,7 @@ bool Position::MakeMove(Move mv)
 #endif
 
     if (!castling)
-        MovePiece(piece, from, to);
+        MovePiece(piece, from, to, threats);
 
     m_ep = NF;
 
@@ -355,7 +354,14 @@ bool Position::MakeMove(Move mv)
             else if (promotion)
             {
                 Remove(to);
+
+                if (threats)
+                    updateThreats<false>(piece, false, to, threats);
+
                 Put(to, promotion);
+
+                if (threats)
+                    updateThreats<false>(promotion, true, to, threats);
 #if !defined(PURE_HCE)
                 dp0 = piece_id_on(to);
                 evalList.put_piece(dp0, to, PieceAdapter[promotion]);
@@ -399,10 +405,10 @@ bool Position::MakeMove(Move mv)
                 // Order handles FRC edge cases where destinations overlap with starts
                 //
 
-                Remove(from);
-                Remove(rfrom);
-                Put(kto, KING | side);
-                Put(rto, ROOK | side);
+                Remove(from, threats);
+                Remove(rfrom, threats);
+                Put(kto, KING | side, threats);
+                Put(rto, ROOK | side, threats);
                 m_Kings[side] = kto;
 
 #if !defined(PURE_HCE)
@@ -560,6 +566,7 @@ void Position::MakeNullMove()
     m_state->accumulator.computed_accumulation = false;
     m_state->dirtyPiece.dirty_num = 0;
     m_state->dirtyPiece.pieceId[0] = PIECE_ID_NONE;
+    m_state->dirtyThreats.clear();
 #endif
 
     m_ep = NF;
@@ -587,13 +594,17 @@ void Position::UnmakeNullMove()
         m_state = &m_undos[0];
 }
 
-void Position::MovePiece(PIECE p, FLD from, FLD to)
-{
+void Position::MovePiece(PIECE p, FLD from, FLD to, DirtyThreats * threats) {
     assert(from >= 0 && from < 64);
     assert(to >= 0 && to < 64);
     assert(p == m_board[from]);
 
     COLOR side = GetColor(p);
+
+    const U64 moveMask = BB_SINGLE[from] | BB_SINGLE[to];
+
+    if (threats)
+        updateThreats(p, false, from, threats, moveMask);
 
     m_bits[p] ^= BB_SINGLE[from];
     m_bits[p] ^= BB_SINGLE[to];
@@ -606,6 +617,113 @@ void Position::MovePiece(PIECE p, FLD from, FLD to)
 
     m_hash ^= s_hash[from][p];
     m_hash ^= s_hash[to][p];
+
+    if (threats)
+        updateThreats(p, true, to, threats, moveMask);
+}
+
+static inline bool canSliderThreat(PIECE attacked, PIECE slider) {
+    return GetPieceType(attacked) != QUEEN || GetPieceType(slider) == QUEEN;
+}
+
+template <bool Discovered>
+void Position::updateThreats(PIECE p, bool placing, FLD f, DirtyThreats * threats, U64 moveMask) const
+{
+    const U64 occupied        = BitsAll();
+    const U64 occupiedNoKings = occupied ^ (m_bits[KW] | m_bits[KB]);
+    const U64 queens          = m_bits[QW] | m_bits[QB];
+    const U64 rookQueens      = m_bits[RW] | m_bits[RB] | queens;
+    const U64 bishopQueens    = m_bits[BW] | m_bits[BB] | queens;
+
+    const U64 bishopAttacks = BishopAttacks(f, occupied);
+    const U64 rookAttacks   = RookAttacks(f, occupied);
+
+    const PIECE type     = GetPieceType(p);
+    const Piece attacker = PieceAdapter[p];
+
+    U64 sliders = (rookQueens & rookAttacks) | (bishopQueens & bishopAttacks);
+
+    auto processSliders = [&](bool addDirectAttacks) {
+        while (sliders) {
+            const FLD   sliderSq = PopLSB(sliders);
+            const PIECE slider   = m_board[sliderSq];
+
+            //
+            // Taking a piece off a ray uncovers the attack of the slider behind it on
+            // the next piece along that ray, putting one there hides that attack again
+            //
+
+            const U64 ray        = BB_RAY[sliderSq][f];
+            const U64 discovered = ray & (rookAttacks | bishopAttacks) & occupiedNoKings;
+
+            if (discovered && (ray & moveMask) != moveMask) {
+                const FLD   attackedSq = LSB(discovered);
+                const PIECE attacked   = m_board[attackedSq];
+
+                if (canSliderThreat(attacked, slider))
+                    threats->add(PieceAdapter[slider], PieceAdapter[attacked], sliderSq, attackedSq, !placing);
+            }
+
+            if (addDirectAttacks && canSliderThreat(p, slider))
+                threats->add(PieceAdapter[slider], attacker, sliderSq, f, placing);
+        }
+    };
+
+    //
+    // a king is never part of a threat pair, only the rays it blocks matter
+    //
+
+    if (type == KING) {
+        if constexpr (Discovered)
+            processSliders(false);
+
+        return;
+    }
+
+    //
+    // The attack set of a slider is the one the discovered attacks above were worked
+    // out from, so it is taken from there rather than probed a second time
+    //
+
+    U64 attacked = (type == BISHOP) ? bishopAttacks
+                 : (type == ROOK)   ? rookAttacks
+                 : (type == QUEEN)  ? (bishopAttacks | rookAttacks)
+                                    : Attacks(f, occupied, p);
+
+    attacked &= occupiedNoKings;
+
+    U64 incoming = BB_KNIGHT_ATTACKS[f] & (m_bits[NW] | m_bits[NB]);
+
+    if (type == PAWN || type == KNIGHT || type == ROOK)
+        incoming |= (BB_PAWN_ATTACKS[f][WHITE] & m_bits[PB]) | (BB_PAWN_ATTACKS[f][BLACK] & m_bits[PW]);
+
+    switch (type)
+    {
+        case PAWN:
+            attacked &= m_bits[PW] | m_bits[PB] | m_bits[NW] | m_bits[NB] | m_bits[RW] | m_bits[RB];
+            break;
+        case BISHOP:
+        case ROOK:
+            attacked &= ~queens;
+            break;
+        default:
+            break;
+    }
+
+    while (attacked) {
+        const FLD to = PopLSB(attacked);
+        threats->add(attacker, PieceAdapter[m_board[to]], f, to, placing);
+    }
+
+    if constexpr (Discovered)
+        processSliders(true);
+    else
+        incoming |= (type == QUEEN) ? (sliders & queens) : sliders;
+
+    while (incoming) {
+        const FLD from = PopLSB(incoming);
+        threats->add(PieceAdapter[m_board[from]], attacker, from, f, placing);
+    }
 }
 
 void Position::Print() const
@@ -632,7 +750,7 @@ void Position::Print() const
     }
 }
 
-void Position::Put(FLD f, PIECE p)
+void Position::Put(FLD f, PIECE p, DirtyThreats * threats)
 {
     assert(f >= 0 && f < 64);
     assert(p >= 2 && p < 14);
@@ -645,6 +763,9 @@ void Position::Put(FLD f, PIECE p)
     m_hash ^= s_hash[f][p];
     m_matIndex[side] += s_matIndexDelta[p];
     ++m_count[p];
+
+    if (threats)
+        updateThreats(p, true, f, threats);
 }
 
 #if !defined(PURE_HCE)
@@ -715,11 +836,14 @@ void Position::Put(FLD f, PIECE p, PieceId & next_piece_id)
 }
 #endif
 
-void Position::Remove(FLD f)
+void Position::Remove(FLD f, DirtyThreats * threats)
 {
     assert(f >= 0 && f < 64);
     PIECE p = m_board[f];
     assert(p >= 2 && p < 14);
+
+    if (threats)
+        updateThreats(p, false, f, threats);
 
     COLOR side = GetColor(p);
     m_bits[p] ^= BB_SINGLE[f];

--- a/src/position.h
+++ b/src/position.h
@@ -102,6 +102,7 @@ struct Undo
 #if !defined(PURE_HCE)
     Accumulator accumulator;
     DirtyPiece dirtyPiece;
+    DirtyThreats dirtyThreats;
 #endif
     Undo* previous;
 
@@ -125,6 +126,8 @@ struct Undo
         dirtyPiece.dirty_num  = 0;
         dirtyPiece.pieceId[0] = PIECE_ID_ZERO;
         dirtyPiece.pieceId[1] = PIECE_ID_ZERO;
+
+        dirtyThreats.clear();
 
         for (unsigned int i = 0; i < sizeof(dirtyPiece.old_piece) / sizeof(ExtPieceSquare); ++i)
             for (unsigned int j = 0; j < sizeof(dirtyPiece.old_piece[i].from) / sizeof(PieceSquare); ++j)
@@ -192,10 +195,13 @@ public:
 
 private:
     void Clear();
-    void Put(FLD f, PIECE p);
+    void Put(FLD f, PIECE p, DirtyThreats * threats = nullptr);
     void Put(FLD f, PIECE p, PieceId & next_piece_id);
-    void Remove(FLD f);
-    void MovePiece(PIECE p, FLD from, FLD to);
+    void Remove(FLD f, DirtyThreats * threats = nullptr);
+    void MovePiece(PIECE p, FLD from, FLD to, DirtyThreats * threats = nullptr);
+
+    template <bool Discovered = true>
+    void updateThreats(PIECE p, bool placing, FLD f, DirtyThreats * threats, U64 moveMask = ~0ull) const;
 
     static U64 s_hash[64][14];
     static U64 s_hashSide[2];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -57,6 +57,7 @@ Search::Search() :
     m_threadParams(nullptr),
     m_lazyDepth(0),
     m_smpThreadExit(false),
+    m_stopRequested(false),
     m_lazyPonder(false),
     m_terminateSmp(false),
     m_level(DEFAULT_LEVEL),
@@ -987,6 +988,19 @@ void Search::waitUntilCompletion()
         ; // we must wait explicitely for stop command or a ponderhit
 }
 
+void Search::stopAndWait() {
+    m_ponderHit     = false;
+    m_stopRequested = true;
+
+    while (m_lazyDepth) {
+        indicateWorkersStop();
+        m_flags |= TERMINATED_BY_USER;
+        std::this_thread::yield();
+    }
+
+    std::unique_lock<std::mutex> lk(m_readyMutex);
+}
+
 void Search::isReady()
 {
     indicateWorkersStop();
@@ -998,6 +1012,7 @@ void Search::isReady()
 void Search::stopPrincipalSearch()
 {
     m_ponderHit = false;
+    m_stopRequested = true;
     m_flags |= TERMINATED_BY_USER;
 }
 
@@ -1007,6 +1022,7 @@ void Search::startPrincipalSearch(Time time, bool ponder)
 
     m_readyMutex.lock();
     setTime(time);
+    m_stopRequested = false;
     m_lazyDepth = 1;
     m_lazyPonder = ponder;
     m_readyMutex.unlock();
@@ -1043,6 +1059,9 @@ uint64_t Search::startSearch(Time time, int depth, bool ponderSearch, bool bench
                 m_time.setPonderMode(true); // always run smp threads in analyze mode
         }
     }
+
+    if (m_stopRequested)
+        m_flags |= TERMINATED_BY_USER;
 
     memset(m_pvPrev, 0, sizeof(m_pvPrev));
     memset(m_pvSizePrev, 0, sizeof(m_pvSizePrev));

--- a/src/search.h
+++ b/src/search.h
@@ -78,6 +78,7 @@ public:
     void startPrincipalSearch(Time time, bool ponder);
     void stopPrincipalSearch();
     void isReady();
+    void stopAndWait();
     void setLevel(int level);
     bool setFEN(const std::string& fen);
     bool setInitialPosition();
@@ -151,6 +152,7 @@ private:
     std::condition_variable m_lazycv;
     volatile int m_lazyDepth;
     volatile bool m_smpThreadExit;
+    volatile bool m_stopRequested;
     bool m_lazyPonder;
     static constexpr int m_lmpDepth = 8;
     static constexpr int m_lmpPruningTable[2][9] =

--- a/src/threats.cpp
+++ b/src/threats.cpp
@@ -1,0 +1,322 @@
+/*
+*  Igel - a UCI chess playing engine derived from GreKo 2018.01
+*
+*  Copyright (C) 2026 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*
+*  Igel is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  Igel is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Igel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+//
+// Conceptual idea and network architecture design of threats is from Stockfish
+//
+
+#include "threats.h"
+#include "position.h"
+
+#include <array>
+#include <utility>
+
+namespace
+{
+    constexpr int colOf(int f)  { return f & 7;     }
+    constexpr U64 single(int f) { return 1ull << f; }
+
+    //
+    // Target of a single step, empty when the step leaves the board or wraps a file
+    //
+
+    constexpr U64 step(int f, int delta) {
+        const int to = f + delta;
+
+        if (to < 0 || to > 63)
+            return 0;
+
+        const int dc = colOf(f) - colOf(to);
+        return (dc <= 2 && dc >= -2) ? single(to) : 0ull;
+    }
+
+    constexpr U64 slide(int f, const int (&dirs)[4]) {
+        U64 attacks = 0;
+
+        for (int d : dirs)
+            for (int cur = f; U64 next = step(cur, d); cur += d)
+                attacks |= next;
+
+        return attacks;
+    }
+
+    constexpr U64 hop(int f, const int (&steps)[8]) {
+        U64 attacks = 0;
+
+        for (int d : steps)
+            attacks |= step(f, d);
+
+        return attacks;
+    }
+
+    constexpr int countBits(U64 b) {
+        int n = 0;
+
+        for (; b; b &= b - 1)
+            ++n;
+
+        return n;
+    }
+
+    constexpr int getType(Piece p) { return int(p) & 7;  }
+    constexpr int getSide(Piece p) { return int(p) >> 3; }
+
+    constexpr int rookDirs[4]    = { 8, -8, 1, -1                       };
+    constexpr int bishopDirs[4]  = { 9, 7, -7, -9                       };
+    constexpr int knightSteps[8] = { 17, 15, 10, 6, -6, -10, -15, -17   };
+    constexpr int kingSteps[8]   = { 8, -8, 1, -1, 9, 7, -7, -9         };
+
+    constexpr Piece AllPieces[12] = {
+        W_PAWN, W_KNIGHT, W_BISHOP, W_ROOK, W_QUEEN, W_KING,
+        B_PAWN, B_KNIGHT, B_BISHOP, B_ROOK, B_QUEEN, B_KING
+    };
+
+    constexpr int PAWN_TYPE = getType(W_PAWN);
+
+    constexpr auto pseudoAttacks = []() {
+        std::array<std::array<U64, 64>, 7> attacks{};
+
+        for (int f = 0; f < 64; ++f) {
+            attacks[0][f] = step(f, 7)  | step(f, 9);
+            attacks[1][f] = step(f, -7) | step(f, -9);
+            attacks[2][f] = hop(f, knightSteps);
+            attacks[3][f] = slide(f, bishopDirs);
+            attacks[4][f] = slide(f, rookDirs);
+            attacks[5][f] = attacks[3][f] | attacks[4][f];
+            attacks[6][f] = hop(f, kingSteps);
+        }
+
+        return attacks;
+    }();
+
+    // Mirror horizontally when the king stands on the king side
+    constexpr auto orient = []() {
+        std::array<std::uint8_t, 64> orient{};
+
+        for (int f = 0; f < 64; ++f)
+            orient[f] = colOf(f) >= 4 ? 7 : 0;
+
+        return orient;
+    }();
+
+    constexpr int NumValidTargets[16] = { 0, 6, 10, 8, 8, 10, 0, 0, 0, 6, 10, 8, 8, 10, 0, 0 };
+
+    // [attacker type][attacked type] to the class of the attacked piece, -1 when the pair is not encoded
+    constexpr int TargetClass[6][6] =
+    {
+        {  0,  1, -1,  2, -1, -1 },
+        {  0,  1,  2,  3,  4, -1 },
+        {  0,  1,  2,  3, -1, -1 },
+        {  0,  1,  2,  3, -1, -1 },
+        {  0,  1,  2,  3,  4, -1 },
+        { -1, -1, -1, -1, -1, -1 }
+    };
+
+    struct PieceBlock {
+        int attackCount; // number of (from, to) pseudo attack pairs of this piece
+        int firstIndex;  // first feature index belonging to this piece
+    };
+
+    constexpr auto pieceBlockTables = []() {
+        std::array<PieceBlock, 16>                    blocks{};
+        std::array<std::array<std::uint16_t, 64>, 16> squareOffsets{};
+
+        int firstIndex = 0;
+
+        for (Piece piece : AllPieces) {
+            const int idx = int(piece);
+            int attackCount = 0;
+
+            for (int from = 0; from < 64; ++from) {
+                squareOffsets[idx][from] = static_cast<std::uint16_t>(attackCount);
+
+                if (getType(piece) != PAWN_TYPE)
+                    attackCount += countBits(pseudoAttacks[getType(piece)][from]);
+                else if (from >= 8 && from <= 55) // pawns never stand on the first and the last rank
+                    attackCount += countBits(pseudoAttacks[getSide(piece)][from]);
+            }
+
+            blocks[idx] = { attackCount, firstIndex };
+            firstIndex += NumValidTargets[idx] * attackCount;
+        }
+
+        return std::pair { blocks, squareOffsets };
+    }();
+
+    constexpr auto PieceBlocks   = pieceBlockTables.first;
+    constexpr auto SquareOffsets = pieceBlockTables.second;
+
+    static_assert(PieceBlocks[B_KING].firstIndex == int(THREAT_DIMENSIONS), "threat feature blocks do not add up to the feature set size");
+
+    // [attacker][attacked][attacker square below attacked square] to the start of the pair block
+    constexpr auto pairOffsets = []() {
+        std::array<std::array<std::array<std::uint32_t, 2>, 16>, 16> out{};
+
+        for (auto & attackerRow : out)
+            for (auto & entry : attackerRow)
+                entry = { THREAT_DIMENSIONS, THREAT_DIMENSIONS };
+
+        for (Piece attacker : AllPieces) {
+            for (Piece attacked : AllPieces) {
+                const int attackerType = getType(attacker);
+                const int attackedType = getType(attacked);
+                const int targetClass  = TargetClass[attackerType - 1][attackedType - 1];
+
+                if (targetClass < 0)
+                    continue;
+
+                const int feature = PieceBlocks[attacker].firstIndex + (getSide(attacked) * (NumValidTargets[attacker] / 2) + targetClass) * PieceBlocks[attacker].attackCount;
+
+                //
+                // Two pieces of the same type threaten each other symmetrically, so only
+                // the ordering with the attacker on the higher square carries a feature.
+                //
+
+                const bool enemy     = (int(attacker) ^ int(attacked)) == 8;
+                const bool symmetric = attackerType == attackedType && (enemy || attackerType != PAWN_TYPE);
+
+                out[attacker][attacked][0] = static_cast<std::uint32_t>(feature);
+                out[attacker][attacked][1] = symmetric ? THREAT_DIMENSIONS : static_cast<std::uint32_t>(feature);
+            }
+        }
+
+        return out;
+    }();
+
+    //
+    // [attacker][from] to the attack set of that piece on an empty board. The rank of a
+    // target inside the set is the number of set bits below it, which is a popcount away
+    // - a table holding the rank of every (from, to) pair instead would be eight times
+    // this one and would not stay in the first level cache.
+    //
+
+    constexpr auto attackSet = []() {
+        std::array<std::array<U64, 64>, 16> out{};
+
+        for (Piece piece : AllPieces) {
+            const int attacks = getType(piece) == PAWN_TYPE ? getSide(piece) : getType(piece);
+
+            for (int from = 0; from < 64; ++from)
+                out[int(piece)][from] = pseudoAttacks[attacks][from];
+        }
+
+        return out;
+    }();
+
+    //
+    // How a point of view turns the board around, which is all a side contributes to an
+    // index and is therefore worked out once per walk rather than once per threat.
+    //
+    // The board numbers A8 as 0, the feature layout numbers A1 as 0, so every square is
+    // flipped vertically first. From the black point of view it is flipped once more,
+    // which cancels out, and the colour of both pieces is swapped.
+    //
+
+    struct Perspective {
+        unsigned squares; // turns a square around
+        unsigned pieces;  // turns a piece code around
+    };
+
+    inline Perspective getPerspective(COLOR side, Square ksq) {
+        return { unsigned(SQ_A8 ^ orient[ksq ^ SQ_A8] ^ (SQ_A8 * side)), 8u * side };
+    }
+
+    //
+    // The part of an index that is settled once the attacker and the square it stands on
+    // are known. A piece attacking several others pays for it once instead of per target.
+    //
+
+    struct Origin {
+        const std::array<std::uint32_t, 2> * pairs;   // pair block starts, by attacked piece
+        std::uint32_t                        square;  // start of this square inside the piece block
+        U64                                  attacks; // where the attacker bears from here, on an empty board
+        unsigned                             from;    // the origin square, turned around
+    };
+
+    inline Origin getOrigin(const Perspective & view, Piece attacker, Square from) {
+        const unsigned attackerOriented = unsigned(attacker) ^ view.pieces;
+        const unsigned fromOriented     = unsigned(from) ^ view.squares;
+
+        return { pairOffsets[attackerOriented].data(), SquareOffsets[attackerOriented][fromOriented], attackSet[attackerOriented][fromOriented], fromOriented };
+    }
+
+    inline std::uint32_t getIndex(const Perspective & view, const Origin & origin, Square to, Piece attacked) {
+        const unsigned toOriented = unsigned(to) ^ view.squares;
+        const U64      below      = (1ull << toOriented) - 1;
+
+        return origin.pairs[unsigned(attacked) ^ view.pieces][origin.from < toOriented] + origin.square + countBits(origin.attacks & below);
+    }
+}
+
+std::uint32_t makeThreatIndex(COLOR side, Piece attacker, Square from, Square to, Piece attacked, Square ksq) {
+    const Perspective view = getPerspective(side, ksq);
+
+    return getIndex(view, getOrigin(view, attacker, from), to, attacked);
+}
+
+void getActiveThreatIndexes(const Position & pos, COLOR side, ThreatList & active) {
+    const Square ksq      = pos.King(side);
+    const U64    occupied = pos.BitsAll();
+
+    const Perspective view = getPerspective(side, ksq);
+
+    const U64 pawnTargets        = pos.Bits(PW) | pos.Bits(PB) | pos.Bits(NW) | pos.Bits(NB) | pos.Bits(RW) | pos.Bits(RB);
+    const U64 minorSliderTargets = pawnTargets | pos.Bits(BW) | pos.Bits(BB);
+    const U64 queenTargets       = minorSliderTargets | pos.Bits(QW) | pos.Bits(QB);
+
+    for (COLOR i = 0; i < 2; ++i) {
+        const COLOR attackerSide = side ^ i;
+
+        for (PIECE type = PAWN; type < KING; type += 2) {
+
+            const PIECE p        = static_cast<PIECE>(type | attackerSide);
+            const Piece attacker = PieceAdapter[p];
+            const U64   targets  = (type == PAWN)                    ? pawnTargets
+                                 : (type == KNIGHT || type == QUEEN) ? queenTargets
+                                                                     : minorSliderTargets;
+            U64 bb = pos.Bits(p);
+
+            while (bb) {
+
+                const FLD from = PopLSB(bb);
+                U64 attacks = Attacks(from, occupied, p) & targets;
+
+                if (!attacks)
+                    continue;
+
+                const Origin origin = getOrigin(view, attacker, from);
+
+                while (attacks) {
+                    const FLD to = PopLSB(attacks);
+                    active.add(getIndex(view, origin, to, PieceAdapter[pos[to]]));
+                }
+            }
+        }
+    }
+}
+
+void getChangedThreatIndexes(COLOR side, Square ksq, const DirtyThreats & dirty, ThreatList & removed, ThreatList & added) {
+    const Perspective view = getPerspective(side, ksq);
+
+    for (size_t i = 0; i < dirty.size(); ++i) {
+        const auto & dt = dirty[i];
+        const auto index = getIndex(view, getOrigin(view, dt.attacker(), dt.from()), dt.to(), dt.attacked());
+        (dt.added() ? added : removed).add(index);
+    }
+}

--- a/src/threats.h
+++ b/src/threats.h
@@ -1,0 +1,62 @@
+/*
+*  Igel - a UCI chess playing engine derived from GreKo 2018.01
+*
+*  Copyright (C) 2026 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*
+*  Igel is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  Igel is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Igel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+//
+// Conceptual idea and network architecture design of threats is from Stockfish
+//
+
+#ifndef THREATS_H
+#define THREATS_H
+
+#include <cstdint>
+
+#include "types.h"
+
+class Position;
+
+const std::uint32_t THREAT_HASH_VALUE = 0x8f234cb8u;
+const std::uint32_t THREAT_DIMENSIONS = 60144;
+
+class ThreatList
+{
+public:
+    enum { MAX_LENGTH = 320 };
+
+    void clear() { m_size = 0; }
+    size_t size() const { return m_size; }
+    std::uint16_t operator[](size_t i) const { return m_data[i]; }
+
+    void add(std::uint32_t index) {
+        assert(m_size < MAX_LENGTH);
+        m_data[m_size] = static_cast<std::uint16_t>(index);
+        m_size += (index < THREAT_DIMENSIONS);
+    }
+
+private:
+    std::uint16_t m_data[MAX_LENGTH];
+    size_t m_size = 0;
+};
+
+std::uint32_t makeThreatIndex(COLOR side, Piece attacker, Square from, Square to, Piece attacked, Square ksq);
+
+void getActiveThreatIndexes(const Position & pos, COLOR side, ThreatList & active);
+
+void getChangedThreatIndexes(COLOR side, Square ksq, const DirtyThreats & dirty, ThreatList & removed, ThreatList & added);
+
+#endif // THREATS_H

--- a/src/types.h
+++ b/src/types.h
@@ -226,6 +226,64 @@ struct DirtyPiece {
     ExtPieceSquare new_piece[2];
 };
 
+static constexpr Piece PieceAdapter[14] = {
+    NO_PIECE, NO_PIECE,
+    W_PAWN,   B_PAWN,
+    W_KNIGHT, B_KNIGHT,
+    W_BISHOP, B_BISHOP,
+    W_ROOK,   B_ROOK,
+    W_QUEEN,  B_QUEEN,
+    W_KING,   B_KING
+};
+
+class DirtyThreat
+{
+public:
+    DirtyThreat() = default;
+    DirtyThreat(Piece attacker, Piece attacked, Square from, Square to, bool added) :
+        m_data((std::uint32_t(added) << ADDED_SHIFT)
+             | (std::uint32_t(attacker) << ATTACKER_SHIFT)
+             | (std::uint32_t(attacked) << ATTACKED_SHIFT)
+             | (std::uint32_t(to) << TO_SHIFT)
+             | (std::uint32_t(from) << FROM_SHIFT)) {}
+
+    Piece  attacker() const { return static_cast<Piece>((m_data >> ATTACKER_SHIFT) & 0x0f); }
+    Piece  attacked() const { return static_cast<Piece>((m_data >> ATTACKED_SHIFT) & 0x0f); }
+    Square from() const { return static_cast<Square>((m_data >> FROM_SHIFT) & 0xff); }
+    Square to() const { return static_cast<Square>((m_data >> TO_SHIFT) & 0xff); }
+    bool   added() const { return m_data >> ADDED_SHIFT; }
+
+private:
+    enum {
+        FROM_SHIFT     = 0,
+        TO_SHIFT       = 8,
+        ATTACKED_SHIFT = 16,
+        ATTACKER_SHIFT = 20,
+        ADDED_SHIFT    = 31
+    };
+
+    std::uint32_t m_data;
+};
+
+class DirtyThreats
+{
+public:
+    enum { MAX_LENGTH = 192 };
+
+    void clear() { m_size = 0; }
+    size_t size() const { return m_size; }
+    const DirtyThreat & operator[](size_t i) const { return m_data[i]; }
+
+    void add(Piece attacker, Piece attacked, Square from, Square to, bool added) {
+        assert(m_size < MAX_LENGTH);
+        m_data[m_size++] = DirtyThreat(attacker, attacked, from, to, added);
+    }
+
+private:
+    DirtyThreat m_data[MAX_LENGTH];
+    size_t      m_size;
+};
+
 static constexpr std::uint32_t PieceSquareIndex[COLOR_NB][PIECE_NB] = {
 
     { PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_KING, PS_NONE,

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.6.39";
+const std::string VERSION = "3.7.0";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else
@@ -57,23 +57,6 @@ const std::string ARCHITECTURE = " 64 "
 #endif
 #endif
 ;
-
-/*
-#if defined(ENV64BIT)
-    #if defined(_BTYPE)
-        #if _BTYPE==0
-            const std::string ARCHITECTURE = " 64 POPCNT AVX2";
-        #else
-            const std::string ARCHITECTURE = " 64 BMI2 AVX2";
-    #endif
-    #else
-        const std::string ARCHITECTURE = " 64";
-    #endif
-#else
-    const std::string ARCHITECTURE = " CUSTOM";
-#endif
-*/
-
 #if defined(__linux__) && !defined(__ANDROID__)
 const int MIN_HASH_SIZE = 2;
 #else
@@ -89,7 +72,7 @@ const int MAX_THREADS     = 1024;
 
 int Uci::handleCommands()
 {
-    std::cout << PROGRAM_NAME << " " << VERSION << ARCHITECTURE << " by V. Shcherbyna (Igel author 2018-2025), V. Medvedev (GreKo author 2002-2018)" << std::endl;
+    std::cout << PROGRAM_NAME << " " << VERSION << ARCHITECTURE << " by V. Shcherbyna (Igel author 2018-2026), V. Medvedev (GreKo author 2002-2018)" << std::endl;
 
     if (!TTable::instance().setHashSize(DEFAULT_HASH_SIZE, DEFAULT_THREADS)) {
         std::cout << "Fatal error: unable to allocate memory for transposition table" << std::endl;
@@ -116,7 +99,7 @@ int Uci::handleCommands()
         else if (startsWith(cmd, "ponderhit"))
             onPonderHit();
         else if (startsWith(cmd, "quit"))
-            exit(0);
+            onQuit();
         else if (startsWith(cmd, "ucinewgame"))
             onUciNewGame();
         else if (startsWith(cmd, "uci"))
@@ -127,7 +110,7 @@ int Uci::handleCommands()
             onGenerate(split(cmd));
         else {
             std::cout << "Unknown command. Good bye." << std::endl;
-            exit(0); // important to exit when stdin is gone to prevent issues in OpenBench
+            onQuit(); // important to exit when stdin is gone to prevent issues in OpenBench
         }
     }
 
@@ -203,6 +186,11 @@ void Uci::onGo(commandParams params)
 void Uci::onStop()
 {
     m_searcher.stopPrincipalSearch();
+}
+
+void Uci::onQuit() {
+    m_searcher.stopAndWait();
+    exit(0);
 }
 
 void Uci::onPonderHit()

--- a/src/uci.h
+++ b/src/uci.h
@@ -68,6 +68,7 @@ private:
     void onPosition(commandParams params);
     void onSetOption(commandParams params);
     void onEval();
+    void onQuit();
     bool startsWith(const std::string & str, const std::string & ptrn);
     void onGenerate(commandParams params);
 

--- a/src/unit/test_threats.cpp
+++ b/src/unit/test_threats.cpp
@@ -1,0 +1,249 @@
+/*
+*  Igel - a UCI chess playing engine derived from GreKo 2018.01
+*
+*  Copyright (C) 2026 Volodymyr Shcherbyna <volodymyr@shcherbyna.com>
+*
+*  Igel is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  Igel is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Igel.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "../moves.h"
+#include "../notation.h"
+#include "../position.h"
+#include "../threats.h"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace unit
+{
+
+static const PIECE AllPieces[12] = { PW, PB, NW, NB, BW, BB, RW, RB, QW, QB, KW, KB };
+
+static std::map<int, int> featureCounts(const ThreatList & list)
+{
+    std::map<int, int> counts;
+
+    for (size_t i = 0; i < list.size(); ++i)
+        counts[list[i]]++;
+
+    return counts;
+}
+
+TEST(ThreatFeatureIndex, Positive)
+{
+    InitBitboards();
+
+    const Square ksq = A1;
+
+    std::map<std::uint32_t, std::vector<int>> seen;
+    std::uint32_t highest = 0;
+    bool encoded[7][7] = {};
+
+    for (PIECE attacker : AllPieces) {
+
+        for (FLD from = 0; from < 64; ++from) {
+
+            // pawns never stand on the first or the last rank
+            if (GetPieceType(attacker) == PAWN && (Row(from) == 0 || Row(from) == 7))
+                continue;
+
+            for (U64 attacks = Attacks(from, 0, attacker); attacks; ) {
+
+                const FLD to = PopLSB(attacks);
+
+                for (PIECE attacked : AllPieces) {
+
+                    const std::uint32_t index = makeThreatIndex(WHITE, PieceAdapter[attacker], from, to,
+                                                                PieceAdapter[attacked], ksq);
+
+                    if (index >= THREAT_DIMENSIONS)
+                        continue;
+
+                    highest = std::max(highest, index);
+                    encoded[GetPieceType(attacker) / 2][GetPieceType(attacked) / 2] = true;
+
+                    const std::vector<int> threat = { attacker, from, to, attacked };
+                    auto inserted = seen.emplace(index, threat);
+
+                    EXPECT_TRUE(inserted.second || inserted.first->second == threat)
+                        << "index " << index << " is shared by two different threats";
+                }
+            }
+        }
+    }
+
+    // [attacker][attacked], indexed by piece type / 2, so pawn is 1 and king is 6
+    const bool expected[7][7] = {
+        { false, false, false, false, false, false, false },
+        { false, true,  true,  false, true,  false, false },   // pawn
+        { false, true,  true,  true,  true,  true,  false },   // knight
+        { false, true,  true,  true,  true,  false, false },   // bishop
+        { false, true,  true,  true,  true,  false, false },   // rook
+        { false, true,  true,  true,  true,  true,  false },   // queen
+        { false, false, false, false, false, false, false }    // king
+    };
+
+    for (int a = 0; a < 7; ++a)
+        for (int d = 0; d < 7; ++d)
+            EXPECT_EQ(expected[a][d], encoded[a][d]) << "attacker type " << a * 2 << " attacked type " << d * 2;
+
+    EXPECT_EQ(THREAT_DIMENSIONS - 1, highest);
+}
+
+//
+// Reading the board from the black point of view is the same as reading the vertically
+// mirrored board with the colours swapped from the white point of view.
+//
+
+TEST(ThreatFeatureMirror, Positive)
+{
+    InitBitboards();
+
+    for (PIECE attacker : AllPieces) {
+
+        for (FLD from = 0; from < 64; ++from) {
+
+            if (GetPieceType(attacker) == PAWN && (Row(from) == 0 || Row(from) == 7))
+                continue;
+
+            for (U64 attacks = Attacks(from, 0, attacker); attacks; ) {
+
+                const FLD to = PopLSB(attacks);
+
+                for (PIECE attacked : AllPieces) {
+
+                    for (FLD ksq = 0; ksq < 64; ksq += 7) {
+
+                        const Piece a = PieceAdapter[attacker];
+                        const Piece d = PieceAdapter[attacked];
+
+                        const std::uint32_t black = makeThreatIndex(BLACK, a, from, to, d, ksq);
+                        const std::uint32_t white = makeThreatIndex(WHITE, Piece(a ^ 8), from ^ SQ_A8,
+                                                                    to ^ SQ_A8, Piece(d ^ 8), ksq ^ SQ_A8);
+
+                        EXPECT_EQ(white, black);
+                    }
+                }
+            }
+        }
+    }
+}
+
+//
+// The heart of the incremental update: the threats a move reports as switched off and
+// on must turn the feature set that was active before the move into the one active
+// after it. Checked over a full move tree so that captures, promotions, en passant,
+// castling and Fischer random castling all take part.
+//
+
+static void checkThreatUpdates(Position & pos, int depth)
+{
+    if (depth == 0)
+        return;
+
+    MoveList mvlist;
+
+    if (pos.InCheck())
+        GenMovesInCheck(pos, mvlist);
+    else
+        GenAllMoves(pos, mvlist);
+
+    const std::string fen = pos.FEN();
+
+    ThreatList before[COLOR_NB];
+    FLD        kingBefore[COLOR_NB];
+
+    for (COLOR c = 0; c < COLOR_NB; ++c) {
+        getActiveThreatIndexes(pos, c, before[c]);
+        kingBefore[c] = pos.King(c);
+    }
+
+    for (size_t i = 0; i < mvlist.Size(); ++i) {
+
+        const Move mv = mvlist[i].m_mv;
+
+        if (!pos.MakeMove(mv))
+            continue;
+
+        EXPECT_LE(pos.state()->dirtyThreats.size(), size_t(DirtyThreats::MAX_LENGTH));
+
+        for (COLOR c = 0; c < COLOR_NB; ++c) {
+
+            // a move of this king refreshes its whole perspective, the dirty list
+            // is not expected to describe that
+            if (pos.King(c) != kingBefore[c])
+                continue;
+
+            ThreatList after, removed, added;
+
+            getActiveThreatIndexes(pos, c, after);
+            getChangedThreatIndexes(c, pos.King(c), pos.state()->dirtyThreats, removed, added);
+
+            std::map<int, int> expected = featureCounts(before[c]);
+
+            for (size_t k = 0; k < removed.size(); ++k)
+                expected[removed[k]]--;
+
+            for (size_t k = 0; k < added.size(); ++k)
+                expected[added[k]]++;
+
+            for (auto it = expected.begin(); it != expected.end(); )
+                it = (it->second == 0) ? expected.erase(it) : std::next(it);
+
+            EXPECT_EQ(expected, featureCounts(after))
+                << "fen " << fen << " move " << MoveToStrLong(mv) << " perspective " << int(c);
+        }
+
+        checkThreatUpdates(pos, depth - 1);
+        pos.UnmakeMove();
+    }
+}
+
+TEST(ThreatIncrementalUpdate, Positive)
+{
+    InitBitboards();
+    Position::InitHashNumbers();
+
+    struct Case { const char * fen; int depth; bool frc; };
+
+    const Case cases[] = {
+        { STD_POSITION,                                                          3, false },
+        { "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -",     3, false },
+        { "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - -",                               4, false },
+        { "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1",    3, false },
+        { "8/PPPk4/8/8/8/8/4Kppp/8 w - - 0 1",                                   4, false },
+        { "n1n5/PPPk4/8/8/8/8/4Kppp/5N1N b - - 0 1",                             3, false },
+        { "bqnb1rkr/pp3ppp/3ppn2/2p5/5P2/P2P4/NPP1P1PP/BQ1BNRKR w HFhf - 2 9",   3, true  },
+        { "qrkrbbnn/pppppppp/8/8/8/8/PPPPPPPP/QRKRBBNN w DBdb - 0 1",            3, true  },
+    };
+
+    const bool chess960 = g_uci_chess960;
+
+    for (const Case & c : cases) {
+
+        g_uci_chess960 = c.frc;
+
+        std::unique_ptr<Position> pos(new Position);
+        ASSERT_EQ(true, pos->SetFEN(c.fen));
+
+        checkThreatUpdates(*pos.get(), c.depth);
+    }
+
+    g_uci_chess960 = chess960;
+}
+
+}


### PR DESCRIPTION
What's new:

* fix draw detection
* fix history overflow
* fix mate score for probcut
* use fifty move guard on tt in qsearch
* update piece stack for null move pruning
* improve tt replace strategy
* fix ply coherence in singular search
* fix undefined behavior in history
* fix undo bug
* apply incheck futility guard
* use tt for skipmove positions
* order moves during probcut
* detect bmi2 in basic makefile
* revert standard network back to c049c117
* support vnni256
* optimize quiets pickup
* speed-up castling
* store tt wdl result as a bonus
* fix tb probing with wrong castling rights
* reduce tt captures
* minimize see calls
* implement finny table
* implement counter move table
* track best move stability
* use tt for null moves
* release new standard network
* implement evalfile parameter
* fix tb tt bug
* restore hce build for tcec
* probe dtz
* fix tt castling bit for frc
* cache hash entry
* speed-up inferencing code
* implement avx512 support
* improve voting system
* fix gcc14 build
* implement frc mode
* improve speed
* support longer games
* optimize sort
* penalize bad captures

Regression run against Igel 3.6.0 at Long Time Control (60+0.6)

Score of Igel 3.7.0 64 BMI2 AVX512 VNNI512 vs Igel 3.6.0 64 BMI2 AVX2: 6161 - 1832 - 7449  [0.640] 15442
Elo difference: 100.1 +/- 3.9, LOS: 100.0 %, DrawRatio: 48.2 %

Regression run against Igel 3.6.0 at Short Time Control (10+0.1)

Score of Igel 3.7.0 64 BMI2 AVX512 VNNI512 vs Igel 3.6.0 64 BMI2 AVX2: 7122 - 2188 - 7167  [0.650] 16477
Elo difference: 107.3 +/- 4.0, LOS: 100.0 %, DrawRatio: 43.5 %

bench: 3488173