### PR TITLE
3.7.1: update statistics for tb moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -855,7 +855,7 @@ bool Search::ProbeHash(TEntry & hentry, U64 hash)
 }
 
 #if defined (SYZYGY_SUPPORT)
-Move Search::tableBaseRootSearch()
+Move Search::tableBaseRootSearch(EVAL & tbScore)
 {
     if (!TB_LARGEST || countBits(m_position.BitsAll()) > TB_LARGEST)
         return 0;
@@ -879,6 +879,20 @@ Move Search::tableBaseRootSearch()
 
     if (result == TB_RESULT_FAILED || result == TB_RESULT_CHECKMATE || result == TB_RESULT_STALEMATE)
         return 0;
+
+    EVAL wdlScore;
+
+    switch (TB_GET_WDL(result)) {
+    case TB_WIN:
+        wdlScore = TBBASE_SCORE - MAX_PLY;
+        break;
+    case TB_LOSS:
+        wdlScore = -TBBASE_SCORE + MAX_PLY;
+        break;
+    default:
+        wdlScore = DRAW_SCORE;
+        break;
+    }
 
     //
     // Different board representation
@@ -931,8 +945,10 @@ Move Search::tableBaseRootSearch()
 
     auto mvSize = moves.Size();
     for (size_t i = 0; i < mvSize; ++i) {
-        if (moves[i].m_mv == tableBaseMove)
+        if (moves[i].m_mv == tableBaseMove) {
+            tbScore = wdlScore;
             return tableBaseMove;
+        }
     }
 
     assert(false);
@@ -1103,10 +1119,24 @@ uint64_t Search::startSearch(Time time, int depth, bool ponderSearch, bool bench
         //  Probe tablebases/tt at root
         //
 
-        auto bestTb = tableBaseRootSearch();
+        EVAL tbScore = DRAW_SCORE;
+        auto bestTb = tableBaseRootSearch(tbScore);
 
         if (bestTb) {
             waitUntilCompletion();
+
+            //
+            //  Update statistics even when playing tb moves
+            //
+
+            ++m_nodes;
+            ++m_tbHits;
+
+            if (!(m_flags & MODE_SILENT)) {
+                auto dt = GetProcTime() - m_t0;
+                printPV(m_position, 1, 1, tbScore, m_pv[0], 0, bestTb, m_nodes, m_tbHits, dt ? 1000 * m_nodes / dt : 1000 * m_nodes);
+            }
+
             printBestMove(this, m_position, bestTb, m_ponder);
             return 1;
         }

--- a/src/search.h
+++ b/src/search.h
@@ -90,7 +90,7 @@ private:
     void lazySmpSearcher();
     void indicateWorkersStop();
 #if defined (SYZYGY_SUPPORT)
-    Move tableBaseRootSearch();
+    Move tableBaseRootSearch(EVAL & tbScore);
 #endif
     EVAL abSearch(EVAL alpha, EVAL beta, int depth, int ply, bool isNull, bool rootNode, bool cutNode, Move skipMove = 0);
     EVAL qSearch(EVAL alpha, EVAL beta, int ply, int depth, bool isNull = false);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.7.0";
+const std::string VERSION = "3.7.1";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
Elo   | 4.35 +- 3.59 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 9662 W: 2378 L: 2257 D: 5027
Penta | [41, 1083, 2452, 1224, 31]
https://chess.grantnet.us/test/40833/

bench: 3488173