### PR TITLE
3.7.2: handle enpassants with tb

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -860,6 +860,13 @@ Move Search::tableBaseRootSearch(EVAL & tbScore)
     if (!TB_LARGEST || countBits(m_position.BitsAll()) > TB_LARGEST)
         return 0;
 
+    FLD epSquare = m_position.EP();
+
+    if (epSquare == NF)
+        epSquare = 0;
+    else
+        epSquare = static_cast<FLD>(abs(int(epSquare) - 63));
+
     auto result =
         tb_probe_root(m_position.BitsAll(WHITE), m_position.BitsAll(BLACK),
             m_position.Bits(KW) | m_position.Bits(KB),
@@ -870,7 +877,7 @@ Move Search::tableBaseRootSearch(EVAL & tbScore)
             m_position.Bits(PW) | m_position.Bits(PB),
             m_position.Fifty(),
             m_position.Castlings(),
-            0,
+            epSquare,
             m_position.Side() == WHITE, nullptr);
 
     //
@@ -905,12 +912,12 @@ Move Search::tableBaseRootSearch(EVAL & tbScore)
 
     Move tableBaseMove;
 
-    assert(!ep);
-
     PIECE piece = m_position[from];
-    PIECE capture = m_position[to];
+    PIECE capture = ep ? static_cast<PIECE>(piece ^ 1) : m_position[to];
 
-    if (!promoted && !ep)
+    if (ep)
+        tableBaseMove = Move(from, to, piece, capture);
+    else if (!promoted)
         tableBaseMove = Move(from, to, piece, capture);
     else {
         switch (promoted)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <sstream>
 
-const std::string VERSION = "3.7.1";
+const std::string VERSION = "3.7.2";
 #if defined(PURE_HCE)
 const std::string PROGRAM_NAME = "Igel HCE";
 #else


### PR DESCRIPTION
Elo   | -0.18 +- 0.94 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 140020 W: 33463 L: 33537 D: 73020
Penta | [557, 16389, 36185, 16329, 550]
https://chess.grantnet.us/test/40838/

bench: 3488173